### PR TITLE
Update gjc to work with latest version of the jpo-ode 4.1.0

### DIFF
--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <scm>
-        <developerConnection>scm:git:https://github.com/usdot-jpo-ode/jpo-ode.git</developerConnection>
+        <developerConnection>scm:git:https://github.com/usdot-jpo-ode/jpo-geojsonconverter.git</developerConnection>
         <tag>jpo-geojsonconverter-usdot-2.2.0</tag>
     </scm>
 

--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -9,15 +9,21 @@
         <version>3.1.3</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
+
+    <scm>
+        <developerConnection>scm:git:https://github.com/usdot-jpo-ode/jpo-ode.git</developerConnection>
+        <tag>jpo-geojsonconverter-usdot-2.2.0</tag>
+    </scm>
+
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-geojsonconverter</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <packaging>jar</packaging>
     <name>jpo-geojsonconverter</name>
     <description>J2735 message to GeoJSON converter for US DOT ITS JPO ODE</description>
     <properties>
         <java.version>21</java.version>
-        <jpoode.version>4.0.0</jpoode.version>
+        <jpoode.version>4.1.0</jpoode.version>
         <sonar.organization>usdot-jpo-ode</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.exclusions>src/main/**/GeoJsonConverterApplication.java,

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/GeoJsonConverterProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/GeoJsonConverterProperties.java
@@ -30,7 +30,6 @@ import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp;
 
 import us.dot.its.jpo.geojsonconverter.pojos.GeometryOutputMode;
-import us.dot.its.jpo.ode.util.CommonUtils;
 
 @ConfigurationProperties("geojsonconverter")
 public class GeoJsonConverterProperties implements EnvironmentAware {
@@ -73,7 +72,7 @@ public class GeoJsonConverterProperties implements EnvironmentAware {
     @PostConstruct
     public void initialize() {
         if (kafkaBrokers == null) {
-            String dockerIp = CommonUtils.getEnvironmentVariable("DOCKER_HOST_IP");
+            String dockerIp = getEnvironmentVariable("DOCKER_HOST_IP");
 
             if (dockerIp == null) {
                 logger.warn(
@@ -85,12 +84,12 @@ public class GeoJsonConverterProperties implements EnvironmentAware {
                     kafkaBrokers);
         }
 
-        String kafkaType = CommonUtils.getEnvironmentVariable("KAFKA_TYPE");
+        String kafkaType = getEnvironmentVariable("KAFKA_TYPE");
         if (kafkaType != null) {
             confluentCloudEnabled = kafkaType.equals("CONFLUENT");
             if (confluentCloudEnabled) {
-                confluentKey = CommonUtils.getEnvironmentVariable("CONFLUENT_KEY");
-                confluentSecret = CommonUtils.getEnvironmentVariable("CONFLUENT_SECRET");
+                confluentKey = getEnvironmentVariable("CONFLUENT_KEY");
+                confluentSecret = getEnvironmentVariable("CONFLUENT_SECRET");
             }
         }
     }
@@ -263,5 +262,13 @@ public class GeoJsonConverterProperties implements EnvironmentAware {
 
     public int getKafkaLingerMs() {
         return lingerMs;
+    }
+
+    private static String getEnvironmentVariable(String variableName) {
+        String value = System.getenv(variableName);
+        if (value == null || value.equals("")) {
+            System.out.println("Something went wrong retrieving the environment variable " + variableName);
+        }
+        return value;
     }
 }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/GeoJsonConverterPropertiesTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/GeoJsonConverterPropertiesTest.java
@@ -11,7 +11,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.boot.info.BuildProperties;
 
-import us.dot.its.jpo.ode.util.CommonUtils;
 
 
 public class GeoJsonConverterPropertiesTest {
@@ -19,7 +18,6 @@ public class GeoJsonConverterPropertiesTest {
     
     GeoJsonConverterProperties testGeoJsonConverterProperties;
     BuildProperties mockBuildProperties;
-    CommonUtils capturingCommonUtils;
 
     @Before
     public void setup() {


### PR DESCRIPTION
Updates the jpo-ode version to point to the latest version. Small modification made to replace jpo-ode class that no longer exists for pulling environment variables.