### PR TITLE
Removes Kafka as a startup dependency for the GJC.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,9 @@ services:
         max-size: "10m"
         max-file: "5"
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy
+        required: false
 
   # ODE Services:
   ode:
@@ -83,6 +85,7 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
+        required: false
     healthcheck:
       test: ["CMD", "wget", "--spider", "http://localhost:8080"]
       interval: 5s
@@ -117,6 +120,7 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
+        required: false
     logging:
       options:
         max-size: "10m"


### PR DESCRIPTION
This PR adds the required: false tag to the Kafka service when building the geojson converter. This addition allows for the GJC to be built without also needing to build and bring up the Kafka service. This can be useful in situations where the Kafka broker is defined somewhere else (for example if using Confluent Cloud) or built alongside another component (like the ODE).

By adding the required: false tag to the docker-compose file, the GJC will be allowed to build if Kafka is unavailable. If Kafka is available, the GJC will wait for the Kafka Service to be up and healthy before proceeding. 
