### PR TITLE
Updating time generation logic to function with null DSecond

### DIFF
--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-geojsonconverter</artifactId>
-    <version>3.0.3</version>
+    <version>3.0.4</version>
     <packaging>jar</packaging>
     <name>jpo-geojsonconverter</name>
     <description>J2735 message to GeoJSON converter for US DOT ITS JPO ODE</description>

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverter.java
@@ -105,8 +105,11 @@ public class SpatProcessedJsonConverter
         processedSpat.setName(intersectionState.getName() != null ? intersectionState.getName().getValue() : null);
         IntersectionReferenceID intersectionReferenceID = intersectionState.getId();
         ProcessedIntersectionReferenceID processedIntersectionReferenceID = new ProcessedIntersectionReferenceID();
-        processedIntersectionReferenceID.setId(intersectionReferenceID.getId() != null ? (int)intersectionReferenceID.getId().getValue() : null);
-        processedIntersectionReferenceID.setRegion(intersectionReferenceID.getRegion() != null ? (int)intersectionReferenceID.getRegion().getValue() : null);
+        processedIntersectionReferenceID.setId(
+                intersectionReferenceID.getId() != null ? (int) intersectionReferenceID.getId().getValue() : null);
+        processedIntersectionReferenceID.setRegion(
+                intersectionReferenceID.getRegion() != null ? (int) intersectionReferenceID.getRegion().getValue()
+                        : null);
         processedSpat.setIntersectionReferenceID(processedIntersectionReferenceID);
 
         // Handle validation messages for the J2735 and CTI-4501 SPaT conformance validation
@@ -136,16 +139,16 @@ public class SpatProcessedJsonConverter
         processedSpat.setStatus(processedStatus);
         List<Integer> enabledLanes = new ArrayList<>();
         if (intersectionState.getEnabledLanes() != null) {
-            enabledLanes.addAll(intersectionState.getEnabledLanes().stream().map(laneId -> (int)laneId.getValue()).toList());
+            enabledLanes.addAll(
+                    intersectionState.getEnabledLanes().stream().map(laneId -> (int) laneId.getValue()).toList());
         }
         processedSpat.setEnabledLanes(enabledLanes);
 
         // Retrieve all relevant timestamp-based fields to calculate the UTC timestamp
-        Integer spatMoy = spat.getTimeStamp() != null ? (int) spat.getTimeStamp().getValue() : null;
-        Integer intersectionMoy =
-                intersectionState.getMoy() != null ? (int) intersectionState.getMoy().getValue() : null;
-        Integer intersectionDSecond =
-                intersectionState.getTimeStamp() != null ? (int) intersectionState.getTimeStamp().getValue() : null;
+        Long spatMoy = spat.getTimeStamp() != null ? spat.getTimeStamp().getValue() : null;
+        Long intersectionMoy = intersectionState.getMoy() != null ? intersectionState.getMoy().getValue() : null;
+        Long intersectionDSecond =
+                intersectionState.getTimeStamp() != null ? intersectionState.getTimeStamp().getValue() : null;
 
         // Generate the UTC timestamp based on the moy that isn't null and let the function handle the rest
         // If both are null or intersectionDSecond is null, the function will still use the ODE received timestamp to
@@ -169,8 +172,9 @@ public class SpatProcessedJsonConverter
                 for (MovementEvent incomingMovementEvent : signalGroupState.getState_time_speed()) {
                     ProcessedMovementEvent processedMovementEvent = new ProcessedMovementEvent();
                     MovementPhaseState phaseState = incomingMovementEvent.getEventState();
-                    if  (phaseState != null) {
-                        ProcessedMovementPhaseState processedMovementPhaseState = ProcessedMovementPhaseState.fromName(phaseState.getName());
+                    if (phaseState != null) {
+                        ProcessedMovementPhaseState processedMovementPhaseState =
+                                ProcessedMovementPhaseState.fromName(phaseState.getName());
                         processedMovementEvent.setEventState(processedMovementPhaseState);
                     }
 
@@ -222,13 +226,14 @@ public class SpatProcessedJsonConverter
             for (AdvisorySpeed advisorySpeed : advisorySpeedList) {
                 ProcessedAdvisorySpeed processedAdvisorySpeed = new ProcessedAdvisorySpeed();
 
-                Integer speed = advisorySpeed.getSpeed() != null ? (int)advisorySpeed.getSpeed().getValue() : null;
+                Integer speed = advisorySpeed.getSpeed() != null ? (int) advisorySpeed.getSpeed().getValue() : null;
                 processedAdvisorySpeed.setSpeed(speed);
 
-                Integer class_ = advisorySpeed.getClass_() != null ? (int)advisorySpeed.getClass_().getValue() : null;
+                Integer class_ = advisorySpeed.getClass_() != null ? (int) advisorySpeed.getClass_().getValue() : null;
                 processedAdvisorySpeed.setClass_(class_);
 
-                Integer distance = advisorySpeed.getDistance() != null ? (int)advisorySpeed.getDistance().getValue() : null;
+                Integer distance =
+                        advisorySpeed.getDistance() != null ? (int) advisorySpeed.getDistance().getValue() : null;
                 processedAdvisorySpeed.setDistance(distance);
 
                 AdvisorySpeedType advisorySpeedType = advisorySpeed.getType();
@@ -265,7 +270,7 @@ public class SpatProcessedJsonConverter
         return processedSpat;
     }
 
-    public ZonedDateTime generateUTCTimestamp(Integer moy, Integer dSecond, String odeTimestamp) { //
+    public ZonedDateTime generateUTCTimestamp(Long moy, Long dSecond, String odeTimestamp) { //
         // 2022-10-31T15:40:26.687292Z
         ZonedDateTime date = null;
         try {
@@ -273,13 +278,11 @@ public class SpatProcessedJsonConverter
             int year = odeDate.getYear();
             String dateString;
             long milliseconds;
-            if (moy != null) {
-                long minutes = moy;
-                milliseconds = (long) dSecond; // milliseconds in current minute
+            if (moy != null && dSecond != null) {
                 dateString = String.format("%d-01-01T00:00:00.00Z", year);
                 date = Instant.parse(dateString).atZone(ZoneId.of("UTC"));
-                date = date.plusMinutes(minutes);
-                date = date.plus(milliseconds, ChronoUnit.MILLIS);
+                date = date.plusMinutes(moy);
+                date = date.plus(dSecond, ChronoUnit.MILLIS);
             } else {
                 date = odeDate;
                 if (dSecond != null) {
@@ -289,6 +292,7 @@ public class SpatProcessedJsonConverter
                     date = date.plus(milliseconds, ChronoUnit.MILLIS);
                 }
             }
+
 
         } catch (Exception e) {
             String errMsg = String.format("Failed to generateUTCTimestamp - SpatProcessedJsonConverter. Message: %s",

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverterTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverterTest.java
@@ -7,7 +7,9 @@ import static org.mockito.Mockito.mock;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -97,11 +99,30 @@ public class SpatProcessedJsonConverterTest {
 
     @Test
     public void testGenerateUTCTimestampMOY() {
-        ZonedDateTime moyTime = spatProcessedJsonConverter.generateUTCTimestamp(481801, 30000, "2022-01-01T00:00:00Z");
+        ZonedDateTime moyTime =
+                spatProcessedJsonConverter.generateUTCTimestamp(481801L, 30000L, "2022-01-01T00:00:00Z");
 
         assertNotNull(moyTime);
         assertEquals("DECEMBER", moyTime.getMonth().toString());
         assertEquals(1, moyTime.getDayOfMonth());
+    }
+
+    @Test
+    public void testGenerateUTCTimestampWithNullMoy() {
+        ZonedDateTime testTime = ZonedDateTime.of(2025, 1, 1, 0, 0, 30, 0, ZoneId.of("UTC"));
+        ZonedDateTime spatTime = spatProcessedJsonConverter.generateUTCTimestamp(null, 30000L,
+                testTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+
+        assertEquals(testTime, spatTime);
+    }
+
+    @Test
+    public void testGenerateUTCTimestampWithNullDSecond() {
+        ZonedDateTime testTime = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"));
+        ZonedDateTime spatTime = spatProcessedJsonConverter.generateUTCTimestamp(481801L, null,
+                testTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+
+        assertEquals(testTime, spatTime);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes an issue in the ProcessedSpat generation logic in which a message with a valid minute of year, but a missing DSecond causes the ProcessedSpat generation pipeline to fail. 

For example, the following ASN.1 Message block has a valid timestamp at the root of the message, but is missing a DSecond within the intersectionStateList. Currently, this message causes a decoding failure. 

00135d425d5a000bd5700032600000720204343bcb3cb10040020404343b7b2ed58040020604343bcb3cb10040020804343b7b2ed58040027d04343bcb2ed58040029304343b7b2ed5804002a104343bcb2ed5804002b704343b7b2ed5804000

For messages with incomplete timestamps like this, the current behavior is to take the whichever component of the timestamp is available, and to populate the other part of the timestamp from the OdeReceivedAtTime. In this situation, this means that the MOY field is used to calculate the minute of the year, and the OdeReceivedAt is used to populate the DSecond. 

This strategy encodes as much of the SPaT time data into the message as possible, but could cause downstream inconsistencies. An alternate approach may be to always use the OdeReceivedAt if either timestamp is missing. However, that adjustment could cause breaking changes for existing deployments. 

This PR also switches the ProcessedSpat generation logic to use Longs for the intermediate timestamps. This helps reduce code complexity, where the Longs are converted to Integers and immediately converted back to Longs in the next function.

When this PR is merged, the Intersection-API should be updated to use the new version of the GeoJsonConverter since it inherits this logic from the GJC.


