### PR TITLE
handling edge case where key is negative

### DIFF
--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/IntersectionIdPartitioner.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/IntersectionIdPartitioner.java
@@ -5,12 +5,17 @@ import org.apache.kafka.streams.processor.StreamPartitioner;
 import us.dot.its.jpo.geojsonconverter.serialization.serializers.JsonSerializer;
 
 /**
- * Partitioner that partitions based only on Intersection ID for objects that implement the {@link IntersectionKey} class.
+ * Partitioner that partitions based only on Intersection ID for objects that implement the {@link IntersectionKey}
+ * class.
  *
- * <p>Partitioning ignores the region, so that items with or without a region defined will be on the same partition.</p>
+ * <p>
+ * Partitioning ignores the region, so that items with or without a region defined will be on the same partition.
+ * </p>
  *
- * <p>Objects that don't implement the {@link IntersectionKey} interface are partitioned on the hash of the entire
- * serialized key, the same as the kafka default behavior.</p>
+ * <p>
+ * Objects that don't implement the {@link IntersectionKey} interface are partitioned on the hash of the entire
+ * serialized key, the same as the kafka default behavior.
+ * </p>
  */
 public class IntersectionIdPartitioner<K, V> implements StreamPartitioner<K, V> {
 
@@ -19,18 +24,24 @@ public class IntersectionIdPartitioner<K, V> implements StreamPartitioner<K, V> 
 
 
         if (key instanceof IntersectionKey) {
-            var intersectionKey = (IntersectionKey)key;
+            var intersectionKey = (IntersectionKey) key;
             int intersectionId = intersectionKey.getIntersectionId();
-            return intersectionId % numPartitions;
-        } else {
-            byte[] partitionBytes;
-            try (var serializer = new JsonSerializer<K>()) {
-                partitionBytes = serializer.serialize(topic, key);
+            int intKey = intersectionId % numPartitions;
+
+            // Kafka Partitioning will fail if the Key is negative. This may happen if the intersectionId is -1 which is
+            // used if the intersection is unknown.
+            if (intKey >= 0) {
+                return intKey;
             }
-            return Utils.toPositive(Utils.murmur2(partitionBytes)) % numPartitions;
+
+
         }
 
-
+        byte[] partitionBytes;
+        try (var serializer = new JsonSerializer<K>()) {
+            partitionBytes = serializer.serialize(topic, key);
+        }
+        return Utils.toPositive(Utils.murmur2(partitionBytes)) % numPartitions;
     }
 
 }


### PR DESCRIPTION
The intersection ID partitioner will produce a negative partition index if passed a negative intersection ID. Since -1 is often used to represent cases where an intersection may not be present this can cause the topology to crash. 