### PR TITLE
Processed SRM & SSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,122 @@ Example `ProcessedRtcm` message:
 }
 ```
 
+### ProcessedSrm
 
+The GeoJSON Converter produces `ProcessedSrm` messages from `SignalRequestMessage` (SRM) message frames received from the ODE.
+
+The SRMs are validated with the J2735 JSON schema.  CTI-4501 doesn't have any guidelines for SRMs, so no additional validation is performed beyond J2735 conformance.
+
+SRMs are similar to BSMs in that they are sent from a vehicle and can include the vehicle's location. Unlike BSMs, the location is optional in SRMs, but if it is present it is used as the point geometry of a GeoJSON feature.
+
+It is possible for one SRM to contain requests for multiple lanes at one intersection, or to target more than one intersection, so ProcessedSrm data structures contain a list of requests. We have observed actual data with multiple requests for different lanes in CDOT's installation. The processed structure retains all the requests in the SRM, even if there happened to be requests for more than one intersection.
+
+The Kafka messages for ProcessedSrm use a key containing the RSU ID and VehicleID. The intersection ID and region are not included in the key because of the possibility of a message targeting more than one intersection.
+
+Example `ProcessedSrm` message:
+
+```json
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      -105.0851191,
+      39.5532496
+    ]
+  },
+  "properties": {
+    "schemaVersion": 1,
+    "messageType": "SRM",
+    "odeReceivedAt": "2025-09-26T00:46:10.771Z",
+    "originIp": "172.18.0.1",
+    "asn1": "001D2F72DC028000050890BD481080201F1A62242F5205200408430AB02F236614C002D4D3841D02CA71A8851970D51C3060",
+    "timeStamp": "2025-09-18T06:29:00Z",
+    "sequenceNumber": 5,
+    "vehicleID": "2031825062",
+    "role": "PUBLICTRANSPORT",
+    "latitude": 39.5532496,
+    "longitude": -105.0851191,
+    "elevation": 1679.1000000000001,
+    "heading": 21.3,
+    "transmission": "UNAVAILABLE",
+    "speedMetersPerSecond": 7.74,
+    "requests": [
+      {
+        "intersectionId": 12114,
+        "requestID": 4,
+        "priorityRequestType": "PRIORITYREQUEST",
+        "inboundLaneID": 2,
+        "outboundLaneID": 15,
+        "estimatedTimeOfArrivalDurationSeconds": 36.145000000
+      },
+      {
+        "intersectionId": 12114,
+        "requestID": 5,
+        "priorityRequestType": "PRIORITYREQUEST",
+        "inboundLaneID": 1,
+        "outboundLaneID": 16,
+        "estimatedTimeOfArrivalDurationSeconds": 34.325000000
+      }
+    ],
+    "validationMessages": []
+  }
+}
+```
+
+
+### ProcessedSsm
+
+The GeoJSON Converter produces `ProcessedSsm` messages from `SignalStatusMessage` (SSM) message frames received from the ODE.
+
+The SSMs are validated against the J2735 JSON schema.  CTI-4501 doesn't have any guidelines for SSMs, so no additional validation is performed beyond J2735 conformance.
+
+SSMs are similar to SPATs in that they don't have a geometry of their own but must be matched with a corresponding MAP message to obtain location data. Therefore, ProcessedSsm objects are simple POJOs, not GeoJSON.
+
+Also, like SPATs, SSMs can contain groups of messages for more than one intersection, but it is anticipated that it is unlikely that they actually would, because they are broadcast from RSUs located at one intersection. Therefore, this code takes only the first intersection from any SSM it receives, and logs a warning if an SSM contains more than one intersection. This is the same as how SPATs are treated.
+
+It also would be possible for SSMs to contain responses for more than one vehicle, or for requests for more than one lane for a vehicle. We have not seen examples of SSMs with multiple statuses in a cursory check of one day of data from CDOT, but this scenario seems more likely that it could happen according to the language in the J2735 where SSMs are defined, which describes them as collections of statuses targeted for multiple vehicles and lanes. For this reason, the ProcessedSsm data structure contains a list of statuses.
+
+The Kafka messages for ProcessedSsm use RSU ID and Intersection in the key because they are associated with only one intersection.
+
+Example `ProcessedSsm` message:
+
+```json
+{
+  "schemaVersion": 1,
+  "messageType": "SSM",
+  "asn1": "001E2565B8056D601800E8BD482C95E46CC2981028200807C30A9325791B30A6050A08010210C2A4",
+  "odeReceivedAt": "2025-09-26T00:55:06.425Z",
+  "originIp": "172.18.0.1",
+  "timeStamp": "2025-09-18T06:29:28Z",
+  "sequenceNumber": 12,
+  "statusSequenceNumber": 29,
+  "intersectionId": 12114,
+  "statusList": [
+    {
+      "vehicleID": "2031825062",
+      "requestID": 4,
+      "requesterSequenceNumber": 5,
+      "requesterRole": "PUBLICTRANSPORT",
+      "inboundOnLaneID": 2,
+      "outboundOnLaneID": 15,
+      "estimatedTimeOfArrivalDurationSeconds": 34.325000000,
+      "status": "PROCESSING"
+    },
+    {
+      "vehicleID": "2031825062",
+      "requestID": 5,
+      "requesterSequenceNumber": 5,
+      "requesterRole": "PUBLICTRANSPORT",
+      "inboundOnLaneID": 1,
+      "outboundOnLaneID": 16,
+      "estimatedTimeOfArrivalDurationSeconds": 34.325000000,
+      "status": "PROCESSING"
+    }
+  ],
+  "validationMessages": []
+}
+```
 
 
 [Back to top](#toc)

--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-geojsonconverter</artifactId>
-    <version>3.0.6</version>
+    <version>3.1.0</version>
     <packaging>jar</packaging>
     <name>jpo-geojsonconverter</name>
     <description>J2735 message to GeoJSON converter for US DOT ITS JPO ODE</description>

--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-geojsonconverter</artifactId>
-    <version>3.0.5</version>
+    <version>3.0.6</version>
     <packaging>jar</packaging>
     <name>jpo-geojsonconverter</name>
     <description>J2735 message to GeoJSON converter for US DOT ITS JPO ODE</description>

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/GeoJsonConverterProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/GeoJsonConverterProperties.java
@@ -71,6 +71,14 @@ public class GeoJsonConverterProperties implements EnvironmentAware {
     @Getter @Setter private String kafkaTopicOdeRtcmJson;
     @Getter @Setter private String kafkaTopicProcessedRtcm;
 
+    // SRM
+    @Getter @Setter private String kafkaTopicOdeSrmJson;
+    @Getter @Setter private String kafkaTopicProcessedSrm;
+
+    // SSM
+    @Getter @Setter private String kafkaTopicOdeSsmJson;
+    @Getter @Setter private String kafkaTopicProcessedSsm;
+
     private int lingerMs = 0;
 
     private GeometryOutputMode geometryOutputMode = GeometryOutputMode.GEOJSON_ONLY;

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
@@ -335,6 +335,7 @@ public class FieldConversions {
     /**
      * Convert Minute of Year to ZonedDateTime.
      * Requires knowing what year it is.
+     * Value of 527040 represents "invalid"
      * @param minuteOfTheYear DE_MinuteOfYear
      * @param year The year
      * @return ZonedDateTime for the year at the beginning of the minute
@@ -342,6 +343,7 @@ public class FieldConversions {
     public static ZonedDateTime convertMinuteOfYear(final MinuteOfTheYear minuteOfTheYear, final int year) { //
         if (minuteOfTheYear == null) return null;
         final long moy = minuteOfTheYear.getValue();
+        if (moy == 527040L) return null;
         final String dateString = String.format("%d-01-01T00:00:00.00Z", year);
         final ZonedDateTime yearDate = Instant.parse(dateString).atZone(ZoneId.of("UTC"));
         return yearDate.plusMinutes(moy);

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
@@ -3,12 +3,14 @@ package us.dot.its.jpo.geojsonconverter.converter;
 
 import lombok.extern.slf4j.Slf4j;
 import us.dot.its.jpo.asn.j2735.r2024.Common.*;
+import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.DeltaTime;
 import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedBasicVehicleRole;
 import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedRequestImportanceLevel;
 import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedRequestSubRole;
 import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedVehicleType;
 
 import java.time.*;
+import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
@@ -156,6 +158,11 @@ public class FieldConversions {
             returnValue = angle * 0.0125;
         }
         return returnValue;
+    }
+
+    public static Double convertLaneWidth(LaneWidth laneWidth) {
+        if (laneWidth == null) { return null; }
+        return laneWidth.getValue()*1e-2d;
     }
 
     public static Double convertSpeed(long speed) {
@@ -353,7 +360,7 @@ public class FieldConversions {
     }
 
     public static AccessPointID convertIntersectionAccessPointID(final IntersectionAccessPoint iap) {
-        if (iap == null) return null;
+        if (iap == null) return new AccessPointID(null, null, null);
 
         // CHOICE of LaneID, ConnectionID, or ApproachID
         Integer laneId = null;
@@ -400,6 +407,22 @@ public class FieldConversions {
             return ProcessedRequestImportanceLevel.valueOf(importanceLevel.getName());
         }
         return null;
+    }
+
+    /**
+     * DeltaTime ::= INTEGER (-122 .. 121)
+     * -- Supporting a range of +/- 20 minute in steps of 10 seconds
+     * -- the value of -121 shall be used when more than -20 minutes
+     * -- the value of +120 shall be used when more than +20 minutes
+     * -- the value -122 shall be used when the value is unavailable
+     * @param deltaTime The difference from scheduled time
+     * @return Duration in seconds
+     */
+    public static Duration convertDeltaTime(final DeltaTime deltaTime) {
+        if (deltaTime == null) { return null; }
+        long value = (int)deltaTime.getValue();
+        if (value == -122L) { return null; }
+        return Duration.ofSeconds(value * 10);
     }
 
 

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
@@ -302,6 +302,37 @@ public class FieldConversions {
         return ZoneOffset.ofHoursMinutes(offsetHours, offsetMinutes);
     }
 
+    final static int MINUTES_PER_DAY = 24 * 60;
+
+    /**
+     * Produce a ZonedDateTime from a minute of the year, and ingest time, adjusting for the edge case where the
+     * message is produced on New Year's Eve and ingested on New Year's Day.
+     * @param minuteOfTheYear J2735 Minute-of-the-year Integer
+     * @param ingestTime The ingest time
+     * @return A ZonedDateTime for the minute of the year
+     */
+    public static ZonedDateTime convertMinuteOfYear(final MinuteOfTheYear minuteOfTheYear, final ZonedDateTime ingestTime) {
+        if (minuteOfTheYear == null) return null;
+        final int moy = (int)minuteOfTheYear.getValue();
+        final int dayOfYear = (moy / MINUTES_PER_DAY) + 1;
+        final boolean isLastDayOfYear = dayOfYear >= 365; // or second to last if leap year
+
+        // J2735 (2024) - Section 7.109: Says DE_Minute of the year is the "current year in the time system being used
+        // (typically UTC time)" so we assume it is in fact UTC time.
+        final ZonedDateTime utcIngestTime = ingestTime.withZoneSameInstant(ZoneOffset.UTC);
+        final int ingestDayOfYear = utcIngestTime.getDayOfYear();
+        final boolean isIngestFirstDayOfYear = (ingestDayOfYear == 1);
+
+        int year = utcIngestTime.getYear();
+        // If it is first or last day of the year and ingest day of year differs from the message day of year
+        // guess the message was produced last year.
+        if (isLastDayOfYear && isIngestFirstDayOfYear) {
+            --year;
+        }
+
+        return convertMinuteOfYear(minuteOfTheYear, year);
+    }
+
     /**
      * Convert Minute of Year to ZonedDateTime.
      * Requires knowing what year it is.
@@ -317,8 +348,18 @@ public class FieldConversions {
         return yearDate.plusMinutes(moy);
     }
 
+    public static ZonedDateTime convertMinuteOfYearAndDSecond(final MinuteOfTheYear minuteOfTheYear,
+                                                              final ZonedDateTime ingestTime, final DSecond dSecond) {
+        ZonedDateTime minuteDate = convertMinuteOfYear(minuteOfTheYear, ingestTime);
+        return convertMinuteOfYearAndDSecond(minuteDate, dSecond);
+    }
+
     public static ZonedDateTime convertMinuteOfYearAndDSecond(final MinuteOfTheYear minuteOfTheYear, final int year, final DSecond dSecond) {
         ZonedDateTime minuteDate = convertMinuteOfYear(minuteOfTheYear, year);
+        return convertMinuteOfYearAndDSecond(minuteDate, dSecond);
+    }
+
+    private static ZonedDateTime convertMinuteOfYearAndDSecond(final ZonedDateTime minuteDate, final DSecond dSecond) {
         if (minuteDate == null) return null;
         if (dSecond == null) return minuteDate;
         SecondNanos secondNanos = convertDSecond(dSecond);
@@ -326,6 +367,8 @@ public class FieldConversions {
                 .withSecond(secondNanos.secondOfMinute())
                 .withNano(secondNanos.nanoOfSecond());
     }
+
+
 
     public static Integer convertMsgCount(final MsgCount msgCount) {
         if (msgCount == null) return null;

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
@@ -3,6 +3,10 @@ package us.dot.its.jpo.geojsonconverter.converter;
 
 import lombok.extern.slf4j.Slf4j;
 import us.dot.its.jpo.asn.j2735.r2024.Common.*;
+import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedBasicVehicleRole;
+import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedRequestImportanceLevel;
+import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedRequestSubRole;
+import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedVehicleType;
 
 import java.time.*;
 import java.time.temporal.ChronoUnit;
@@ -332,7 +336,71 @@ public class FieldConversions {
     }
 
     public record RegionIntersectionId(Integer region, Integer intersectionId) {
-
     }
+
+    public static String convertVehicleID(final VehicleID vehicleID) {
+        if (vehicleID == null) return null;
+        // CHOICE of EntityID or StationID
+        // EntityID is an Octet string, StationId is an integer
+        // Return a String in either case
+        if (vehicleID.getEntityID() != null) {
+            return vehicleID.getEntityID().getValue();
+        }
+        if (vehicleID.getStationID() != null) {
+            return Long.toString(vehicleID.getStationID().getValue());
+        }
+        return null;
+    }
+
+    public static AccessPointID convertIntersectionAccessPointID(final IntersectionAccessPoint iap) {
+        if (iap == null) return null;
+
+        // CHOICE of LaneID, ConnectionID, or ApproachID
+        Integer laneId = null;
+        Integer approachId = null;
+        Integer connectionId = null;
+        if (iap.getLane() != null) {
+            laneId = (int)iap.getLane().getValue();
+        }
+        if (iap.getApproach() != null) {
+            approachId = (int)iap.getApproach().getValue();
+        }
+        if (iap.getConnection() != null) {
+            connectionId = (int)iap.getConnection().getValue();
+        }
+        return new AccessPointID(laneId, approachId, connectionId);
+    }
+
+    public record AccessPointID(Integer laneID, Integer approachID, Integer connectionID) {
+    }
+
+    public static ProcessedBasicVehicleRole convertBasicVehicleRole(final BasicVehicleRole role) {
+        if (role != null && role.getName() != null) {
+            return ProcessedBasicVehicleRole.fromName(role.getName());
+        }
+        return null;
+    }
+
+    public static ProcessedRequestSubRole convertRequestSubRole(final RequestSubRole role) {
+        if (role != null && role.getName() != null) {
+            return ProcessedRequestSubRole.fromName(role.getName());
+        }
+        return null;
+    }
+
+    public static ProcessedVehicleType convertVehicleType(final VehicleType vehicleType) {
+        if (vehicleType != null && vehicleType.getName() != null) {
+            return ProcessedVehicleType.fromName(vehicleType.getName());
+        }
+        return null;
+    }
+
+    public static ProcessedRequestImportanceLevel convertRequestImportanceLevel(final RequestImportanceLevel importanceLevel) {
+        if (importanceLevel != null && importanceLevel.getName() != null) {
+            return ProcessedRequestImportanceLevel.valueOf(importanceLevel.getName());
+        }
+        return null;
+    }
+
 
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
@@ -317,15 +317,14 @@ public class FieldConversions {
         final int dayOfYear = (moy / MINUTES_PER_DAY) + 1;
         final boolean isLastDayOfYear = dayOfYear >= 365; // or second to last if leap year
 
-        // J2735 (2024) - Section 7.109: Says DE_Minute of the year is the "current year in the time system being used
-        // (typically UTC time)" so we assume it is in fact UTC time.
+        // J2735 (2024) - Section 7.109: Says DE_Minute of the year is the minute of the "current year in the time
+        // system being used (typically UTC time)" so we assume it is in fact UTC time.
         final ZonedDateTime utcIngestTime = ingestTime.withZoneSameInstant(ZoneOffset.UTC);
         final int ingestDayOfYear = utcIngestTime.getDayOfYear();
         final boolean isIngestFirstDayOfYear = (ingestDayOfYear == 1);
 
         int year = utcIngestTime.getYear();
-        // If it is first or last day of the year and ingest day of year differs from the message day of year
-        // guess the message was produced last year.
+        // If message produced on last day of year, and ingested on first day of year, it was produced last year.
         if (isLastDayOfYear && isIngestFirstDayOfYear) {
             --year;
         }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
@@ -1,12 +1,14 @@
 package us.dot.its.jpo.geojsonconverter.converter;
 
 
+import lombok.extern.slf4j.Slf4j;
 import us.dot.its.jpo.asn.j2735.r2024.Common.*;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.*;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+@Slf4j
 public class FieldConversions {
     public static Double convertLong(long j2735Long) {
         // Longitude ::= INTEGER (-1799999999..1800000001)
@@ -257,7 +259,7 @@ public class FieldConversions {
      * Millisecond of minute.
      *
      * @param dSecond DE_DSecond
-     * @return milliseconds or null if absent
+     * @return second of minute, and nanosecond of second
      */
     public static SecondNanos convertDSecond(DSecond dSecond) {
         if (dSecond == null) return null;
@@ -288,4 +290,49 @@ public class FieldConversions {
         int offsetMinutes = value - (offsetHours * 60);
         return ZoneOffset.ofHoursMinutes(offsetHours, offsetMinutes);
     }
+
+    /**
+     * Convert Minute of Year to ZonedDateTime.
+     * Requires knowing what year it is.
+     * @param minuteOfTheYear DE_MinuteOfYear
+     * @param year The year
+     * @return ZonedDateTime for the year at the beginning of the minute
+     */
+    public static ZonedDateTime convertMinuteOfYear(final MinuteOfTheYear minuteOfTheYear, final int year) { //
+        if (minuteOfTheYear == null) return null;
+        final long moy = minuteOfTheYear.getValue();
+        final String dateString = String.format("%d-01-01T00:00:00.00Z", year);
+        final ZonedDateTime yearDate = Instant.parse(dateString).atZone(ZoneId.of("UTC"));
+        return yearDate.plusMinutes(moy);
+    }
+
+    public static ZonedDateTime convertMinuteOfYearAndDSecond(final MinuteOfTheYear minuteOfTheYear, final int year, final DSecond dSecond) {
+        ZonedDateTime minuteDate = convertMinuteOfYear(minuteOfTheYear, year);
+        if (minuteDate == null) return null;
+        if (dSecond == null) return minuteDate;
+        SecondNanos secondNanos = convertDSecond(dSecond);
+        if (secondNanos == null) return minuteDate;
+        return minuteDate
+                .withSecond(secondNanos.secondOfMinute())
+                .withNano(secondNanos.nanoOfSecond());
+    }
+
+    public static Integer convertMsgCount(final MsgCount msgCount) {
+        if (msgCount == null) return null;
+        return (int)msgCount.getValue();
+    }
+
+    public static RegionIntersectionId convertIntersectionReferenceID(IntersectionReferenceID intersectionReferenceID) {
+        if (intersectionReferenceID == null) return new RegionIntersectionId(null, null);
+        var region = intersectionReferenceID.getRegion();
+        Integer regionValue = region != null ? (int)region.getValue() : null;
+        var id = intersectionReferenceID.getId();
+        Integer idValue = id != null ? (int)id.getValue() : null;
+        return new RegionIntersectionId(regionValue, idValue);
+    }
+
+    public record RegionIntersectionId(Integer region, Integer intersectionId) {
+
+    }
+
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversions.java
@@ -322,7 +322,6 @@ public class FieldConversions {
         if (minuteDate == null) return null;
         if (dSecond == null) return minuteDate;
         SecondNanos secondNanos = convertDSecond(dSecond);
-        if (secondNanos == null) return minuteDate;
         return minuteDate
                 .withSecond(secondNanos.secondOfMinute())
                 .withNano(secondNanos.nanoOfSecond());

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/JsonConverterServiceController.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/JsonConverterServiceController.java
@@ -147,7 +147,7 @@ public class JsonConverterServiceController {
             // SSM
             logger.info("Creating the ProcessedSsm Kafka Streams topology");
             Topology ssmTopology = SsmTopology.build(
-                    geojsonProps.getKafkaTopicOdeSrmJson(),
+                    geojsonProps.getKafkaTopicOdeSsmJson(),
                     geojsonProps.getKafkaTopicProcessedSsm(),
                     ssmJsonValidator,
                     ssmConverter);

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/JsonConverterServiceController.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/JsonConverterServiceController.java
@@ -16,6 +16,10 @@ import us.dot.its.jpo.geojsonconverter.converter.rtcm.RTCMConverter;
 import us.dot.its.jpo.geojsonconverter.converter.rtcm.RTCMTopology;
 import us.dot.its.jpo.geojsonconverter.converter.spat.SpatTopology;
 import us.dot.its.jpo.geojsonconverter.converter.bsm.BsmTopology;
+import us.dot.its.jpo.geojsonconverter.converter.srm.SrmConverter;
+import us.dot.its.jpo.geojsonconverter.converter.srm.SrmTopology;
+import us.dot.its.jpo.geojsonconverter.converter.ssm.SsmConverter;
+import us.dot.its.jpo.geojsonconverter.converter.ssm.SsmTopology;
 import us.dot.its.jpo.geojsonconverter.validator.*;
 
 /**
@@ -29,8 +33,10 @@ public class JsonConverterServiceController {
 
     @Autowired
     public JsonConverterServiceController(GeoJsonConverterProperties geojsonProps, MapJsonValidator mapJsonValidator,
-            SpatJsonValidator spatJsonValidator, BsmJsonValidator bsmJsonValidator, PsmJsonValidator psmJsonValidator,
-                                          RTCMJsonValidator rtcmJsonValidator, RTCMConverter rtcmConverter) {
+                                          SpatJsonValidator spatJsonValidator, BsmJsonValidator bsmJsonValidator, PsmJsonValidator psmJsonValidator,
+                                          RTCMJsonValidator rtcmJsonValidator, RTCMConverter rtcmConverter,
+                                          SrmJsonValidator srmJsonValidator, SrmConverter srmConverter,
+                                          SsmJsonValidator ssmJsonValidator, SsmConverter ssmConverter) {
         super();
 
         try {
@@ -44,7 +50,7 @@ public class JsonConverterServiceController {
                     mapJsonValidator, geojsonProps.getGeometryOutputMode());
             var mapStreams = new KafkaStreams(mapTopology, geojsonProps.createStreamProperties("processedmapjson"));
             mapStreams.setUncaughtExceptionHandler(new StreamsExceptionHandler("MapStream"));
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            Runtime.getRuntime().addShutdownHook(Thread.ofVirtual().unstarted(() -> {
                 try {
                     // Workaround to close streams in a finally block to satisfy sonar
                 } finally {
@@ -60,7 +66,7 @@ public class JsonConverterServiceController {
                     geojsonProps.getKafkaTopicSpatGeoJson(), spatJsonValidator);
             var spatStreams = new KafkaStreams(spatTopology, geojsonProps.createStreamProperties("processedspatjson"));
             spatStreams.setUncaughtExceptionHandler(new StreamsExceptionHandler("SpatStream"));
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            Runtime.getRuntime().addShutdownHook(Thread.ofVirtual().unstarted(() -> {
                 try {
                     // Workaround to close streams in a finally block to satisfy sonar
                 } finally {
@@ -76,7 +82,7 @@ public class JsonConverterServiceController {
                     geojsonProps.getKafkaTopicProcessedBsm(), bsmJsonValidator);
             var bsmStreams = new KafkaStreams(bsmTopology, geojsonProps.createStreamProperties("processedbsmjson"));
             bsmStreams.setUncaughtExceptionHandler(new StreamsExceptionHandler("BsmStream"));
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            Runtime.getRuntime().addShutdownHook(Thread.ofVirtual().unstarted(() -> {
                 try {
                     // Workaround to close streams in a finally block to satisfy sonar
                 } finally {
@@ -92,7 +98,7 @@ public class JsonConverterServiceController {
                     geojsonProps.getKafkaTopicProcessedPsm(), psmJsonValidator);
             var psmStreams = new KafkaStreams(psmTopology, geojsonProps.createStreamProperties("processedpsmjson"));
             psmStreams.setUncaughtExceptionHandler(new StreamsExceptionHandler("PsmStream"));
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            Runtime.getRuntime().addShutdownHook(Thread.ofVirtual().unstarted(() -> {
                 try {
                     // Workaround to close streams in a finally block to satisfy sonar
                 } finally {
@@ -111,7 +117,7 @@ public class JsonConverterServiceController {
             final var rtcmStreams = new KafkaStreams(rtcmTopology,
                     geojsonProps.createStreamProperties("processedrcmjson"));
             rtcmStreams.setUncaughtExceptionHandler(new StreamsExceptionHandler("RTCMStream"));
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            Runtime.getRuntime().addShutdownHook(Thread.ofVirtual().unstarted(() -> {
                 try {
                     // Workaround to close streams in a finally block to satisfy sonar
                 } finally {
@@ -119,6 +125,42 @@ public class JsonConverterServiceController {
                 }
             }));
             rtcmStreams.start();
+
+            // SRM
+            logger.info("Creating the ProcessedSrm Kafka Streams topology");
+            Topology srmTopology = SrmTopology.build(
+                    geojsonProps.getKafkaTopicOdeSrmJson(),
+                    geojsonProps.getKafkaTopicProcessedSrm(),
+                    srmJsonValidator,
+                    srmConverter);
+            final var srmStreams = new KafkaStreams(srmTopology,
+                    geojsonProps.createStreamProperties("processedsrmjson"));
+            Runtime.getRuntime().addShutdownHook(Thread.ofVirtual().unstarted(() -> {
+                try {
+                    // Workaround to close streams in a finally block to satisfy sonar
+                } finally {
+                    srmStreams.close();
+                }
+            }));
+            srmStreams.start();
+
+            // SSM
+            logger.info("Creating the ProcessedSsm Kafka Streams topology");
+            Topology ssmTopology = SsmTopology.build(
+                    geojsonProps.getKafkaTopicOdeSrmJson(),
+                    geojsonProps.getKafkaTopicProcessedSsm(),
+                    ssmJsonValidator,
+                    ssmConverter);
+            final var ssmStreams = new KafkaStreams(ssmTopology,
+                    geojsonProps.createStreamProperties("processedssmjson"));
+            Runtime.getRuntime().addShutdownHook(Thread.ofVirtual().unstarted(() -> {
+                try {
+                    // Workaround to close streams in a finally block to satisfy sonar
+                } finally {
+                    ssmStreams.close();
+                }
+            }));
+            ssmStreams.start();
 
             logger.info("All geoJSON conversion services started!");
         } catch (Exception e) {

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
@@ -20,7 +20,7 @@ import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
 @Slf4j
 public class SrmConverter {
 
-    public List<ProcessedSrm> processedSsm(final SignalRequestMessageMessageFrame ssmFrame) {
+    public List<ProcessedSrm> processSrm(final SignalRequestMessageMessageFrame ssmFrame) {
         // We don't know what year it is; assume it is this year.
         var now = ZonedDateTime.now();
         return processSrm(ssmFrame, now.getYear());
@@ -69,6 +69,7 @@ public class SrmConverter {
     }
 
     private void processRequestorDescription(final RequestorDescription requestor, SrmProperties props) {
+        if (requestor == null) { return; }
         RequestorPositionVector vector = requestor.getPosition();
         processRequestorPositionVector(vector, props);
 
@@ -134,6 +135,7 @@ public class SrmConverter {
     }
 
     private void processSignalRequestPackage(final SignalRequestPackage pkg, final SrmProperties props, final int year) {
+        if (pkg == null) { return; }
         processSignalRequest(pkg.getRequest(), props);
         processETA(pkg, props, year);
     }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
@@ -4,13 +4,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import us.dot.its.jpo.asn.j2735.r2024.Common.*;
 import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.*;
-import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame;
 import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedTransmissionState;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
-import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
-import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
-import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.*;
+import us.dot.its.jpo.geojsonconverter.utils.BitstringUtils;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,8 +53,14 @@ public class SrmConverter {
             var props = new SrmProperties();
             props.setTimeStamp(timeStamp);
             props.setSequenceNumber(sequenceNumber);
-            Point geometry = processRequestorDescription(requestor, props);
-            processSignalRequestPackage(pkg, props);
+            processRequestorDescription(requestor, props);
+            processSignalRequestPackage(pkg, props, year);
+            Point geometry;
+            if (props.getLongitude() != null && props.getLatitude() != null) {
+                geometry = new Point(props.getLongitude(), props.getLatitude());
+            } else {
+                geometry = null;
+            }
             var processed = new ProcessedSrm(geometry, props);
             list.add(processed);
         }
@@ -63,12 +68,40 @@ public class SrmConverter {
         return list;
     }
 
-    private Point processRequestorDescription(final RequestorDescription requestor, SrmProperties props) {
+    private void processRequestorDescription(final RequestorDescription requestor, SrmProperties props) {
         RequestorPositionVector vector = requestor.getPosition();
+        processRequestorPositionVector(vector, props);
 
+        VehicleID id = requestor.getId();
+        props.setVehicleID(convertVehicleID(id));
+
+        DescriptiveName name = requestor.getName();
+        if (name != null) {
+            props.setName(name.getValue());
+        }
+
+        DescriptiveName routeName = requestor.getRouteName();
+        if (routeName != null) {
+            props.setRouteName(routeName.getValue());
+        }
+
+        TransitVehicleOccupancy occupancy = requestor.getTransitOccupancy();
+        if (occupancy != null) {
+            props.setTransitOccupancy(ProcessedTransitVehicleOccupancy.fromName(occupancy.getName()));
+        }
+
+        props.setTransitSchedule(convertDeltaTime(requestor.getTransitSchedule()));
+
+        TransitVehicleStatus status = requestor.getTransitStatus();
+        ProcessedTransitVehicleStatus processedStatus = new ProcessedTransitVehicleStatus();
+        BitstringUtils.processBitstring(processedStatus, status);
+
+        RequestorType type = requestor.getType();
+        processRequestorType(type, props);
+    }
+
+    private void processRequestorPositionVector(RequestorPositionVector vector, SrmProperties props) {
         if (vector != null) {
-
-
             if (vector.getHeading() != null) {
                 props.setHeading(convertHeading(vector.getHeading().getValue()));
             }
@@ -98,31 +131,62 @@ public class SrmConverter {
                 }
             }
         }
+    }
 
-        VehicleID id = requestor.getId();
-        props.setVehicleID(convertVehicleID(id));
+    private void processSignalRequestPackage(final SignalRequestPackage pkg, final SrmProperties props, final int year) {
+        processSignalRequest(pkg.getRequest(), props);
+        processETA(pkg, props, year);
+    }
 
-        DescriptiveName name = requestor.getName();
-        if (name != null) {
-            props.setDescriptiveName(name.getValue());
+    private void processSignalRequest(final SignalRequest request, final SrmProperties props) {
+        if (request == null) return;
+
+        RegionIntersectionId id = convertIntersectionReferenceID(request.getId());
+        props.setRegion(id.region());
+        props.setIntersectionId(id.intersectionId());
+
+        RequestID requestId = request.getRequestID();
+        if (requestId != null) {
+            props.setRequestID((int)requestId.getValue());
         }
-        DescriptiveName routeName = requestor.getRouteName();
 
-        TransitVehicleOccupancy occupancy = requestor.getTransitOccupancy();
-        DeltaTime schedule = requestor.getTransitSchedule();
-        TransitVehicleStatus status = requestor.getTransitStatus();
-        RequestorType type = requestor.getType();
+        PriorityRequestType requestType = request.getRequestType();
+        if (requestType != null) {
+            props.setPriorityRequestType(ProcessedPriorityRequestType.fromName(requestType.getName()));
+        }
 
-        if (props.getLongitude() != null && props.getLatitude() != null) {
-            return new Point(props.getLongitude(), props.getLatitude());
-        } else {
-            return null;
+        AccessPointID inbound = convertIntersectionAccessPointID(request.getInBoundLane());
+        props.setInboundLaneID(inbound.laneID());
+        props.setInboundApproachID(inbound.approachID());
+        props.setInboundLaneConnectionID(inbound.connectionID());
+
+        AccessPointID outbound = convertIntersectionAccessPointID(request.getOutBoundLane());
+        props.setOutboundLaneID(outbound.laneID());
+        props.setOutboundApproachID(outbound.approachID());
+        props.setOutboundLaneConnectionID(outbound.connectionID());
+    }
+
+    private void processETA(final SignalRequestPackage pkg, final SrmProperties props, final int year) {
+        ZonedDateTime ts = convertMinuteOfYearAndDSecond( pkg.getMinute(), year, pkg.getSecond());
+        props.setEstimatedTimeOfArrival(ts);
+        if (pkg.getDuration() != null) {
+            Duration duration = Duration.ofMillis(pkg.getDuration().getValue());
+            props.setEstimatedTimeOfArrivalDuration(duration);
         }
     }
 
-    private void processSignalRequestPackage(SignalRequestPackage pkg, SrmProperties props) {
-
+    private void processRequestorType(RequestorType requestorType, SrmProperties props) {
+        if (requestorType == null) return;
+        props.setRole(convertBasicVehicleRole(requestorType.getRole()));
+        props.setSubrole(convertRequestSubRole(requestorType.getSubrole()));
+        props.setHpmsType(convertVehicleType(requestorType.getHpmsType()));
+        Iso3833VehicleType iso = requestorType.getIso3883();
+        if (iso != null) {
+            props.setIso3833VehicleType((int)iso.getValue());
+        }
+        props.setImportanceLevel(convertRequestImportanceLevel(requestorType.getRequest()));
     }
+
 
 
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
@@ -1,4 +1,83 @@
 package us.dot.its.jpo.geojsonconverter.converter.srm;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import us.dot.its.jpo.asn.j2735.r2024.Common.*;
+import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.*;
+import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
+import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.convertMinuteOfYearAndDSecond;
+import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.convertMsgCount;
+
+@Component
+@Slf4j
 public class SrmConverter {
+
+    public List<ProcessedSrm> processedSsm(final SignalRequestMessageMessageFrame ssmFrame) {
+        // We don't know what year it is; assume it is this year.
+        var now = ZonedDateTime.now();
+        return processSrm(ssmFrame, now.getYear());
+    }
+
+    public List<ProcessedSrm> processSrm(final SignalRequestMessageMessageFrame srmFrame, final int year) {
+        var list = new ArrayList<ProcessedSrm>();
+
+        if (srmFrame == null) {
+            log.error("MessageFrame is null");
+            return list;
+        }
+
+        SignalRequestMessage srm = srmFrame.getValue();
+
+        if (srm == null) {
+            log.error("SignalRequestMessage is null");
+            return list;
+        }
+
+        final Integer sequenceNumber = convertMsgCount(srm.getSequenceNumber());
+        MinuteOfTheYear moy = srm.getTimeStamp();
+        DSecond dsec = srm.getSecond();
+        final ZonedDateTime timeStamp = convertMinuteOfYearAndDSecond(moy, year, dsec);
+
+        RequestorDescription requestor = srm.getRequestor();
+
+        SignalRequestList requests = srm.getRequests();
+        for (SignalRequestPackage pkg : requests) {
+            var props = new SrmProperties();
+            props.setTimeStamp(timeStamp);
+            props.setSequenceNumber(sequenceNumber);
+            Point geometry = processRequestorDescription(requestor, props);
+            processSignalRequestPackage(pkg, props);
+            var processed = new ProcessedSrm(geometry, props);
+            list.add(processed);
+        }
+
+        return list;
+    }
+
+    private Point processRequestorDescription(final RequestorDescription requestor, SrmProperties props) {
+        RequestorPositionVector vector = requestor.getPosition();
+
+        VehicleID id = requestor.getId();
+        DescriptiveName name = requestor.getName();
+        DescriptiveName routeName = requestor.getRouteName();
+        TransitVehicleOccupancy occupancy = requestor.getTransitOccupancy();
+        DeltaTime schedule = requestor.getTransitSchedule();
+        TransitVehicleStatus status = requestor.getTransitStatus();
+        RequestorType type = requestor.getType();
+    }
+
+    private void processSignalRequestPackage(SignalRequestPackage pkg, SrmProperties props) {
+
+    }
+
+
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
@@ -13,6 +13,7 @@ import us.dot.its.jpo.geojsonconverter.utils.BitstringUtils;
 import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
 
 import java.time.Duration;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,12 +26,12 @@ import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
 public class SrmConverter {
 
     public ProcessedSrm processSrm(final SignalRequestMessageMessageFrame ssmFrame) {
-        // We don't know what year it is; assume it is this year.
+        // We don't know what year it is; pass in the current time as a basis to guess the year.
         var now = ZonedDateTime.now();
-        return processSrm(ssmFrame, now.getYear());
+        return processSrm(ssmFrame, now);
     }
 
-    public ProcessedSrm processSrm(final SignalRequestMessageMessageFrame srmFrame, final int year) {
+    public ProcessedSrm processSrm(final SignalRequestMessageMessageFrame srmFrame, final ZonedDateTime ingestTime) {
         var list = new ArrayList<ProcessedSrm>();
 
         if (srmFrame == null) {
@@ -48,7 +49,8 @@ public class SrmConverter {
         final Integer sequenceNumber = convertMsgCount(srm.getSequenceNumber());
         MinuteOfTheYear moy = srm.getTimeStamp();
         DSecond dsec = srm.getSecond();
-        final ZonedDateTime timeStamp = convertMinuteOfYearAndDSecond(moy, year, dsec);
+        final ZonedDateTime timeStamp = convertMinuteOfYearAndDSecond(moy, ingestTime, dsec);
+        final int year = timeStamp != null ? timeStamp.getYear() : ZonedDateTime.now(ZoneOffset.UTC).getYear();
 
         RequestorDescription requestor = srm.getRequestor();
         var props = new SrmProperties();

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
@@ -1,17 +1,22 @@
 package us.dot.its.jpo.geojsonconverter.converter.srm;
 
+import com.networknt.schema.ValidationMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import us.dot.its.jpo.asn.j2735.r2024.Common.*;
 import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.*;
+import us.dot.its.jpo.geojsonconverter.pojos.ProcessedValidationMessage;
 import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedTransmissionState;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.rtcm.RTCMProperties;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.*;
 import us.dot.its.jpo.geojsonconverter.utils.BitstringUtils;
+import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
@@ -194,6 +199,27 @@ public class SrmConverter {
         props.setImportanceLevel(convertRequestImportanceLevel(requestorType.getRequest()));
     }
 
-
+    /**
+     * Add JSON schema validation results for J2735 and Metadata validation.
+     * @param properties The properties to add validation messages to
+     * @param validatorResult the schema validator result
+     */
+    public void jsonValidation(SrmProperties properties, JsonValidatorResult validatorResult) {
+        var messages = new ArrayList<ProcessedValidationMessage>();
+        for (Exception exception : validatorResult.getExceptions()) {
+            var msg = new ProcessedValidationMessage();
+            msg.setMessage(exception.getMessage());
+            msg.setException(Arrays.toString(exception.getStackTrace()));
+            messages.add(msg);
+        }
+        for (ValidationMessage vm : validatorResult.getValidationMessages()) {
+            var msg = new ProcessedValidationMessage();
+            msg.setMessage(vm.getMessage());
+            msg.setSchemaPath(vm.getSchemaPath());
+            msg.setJsonPath(vm.getPath());
+            messages.add(msg);
+        }
+        properties.addValidationMessages(messages);
+    }
 
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import us.dot.its.jpo.asn.j2735.r2024.Common.*;
 import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.*;
 import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedTransmissionState;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
@@ -14,8 +15,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.convertMinuteOfYearAndDSecond;
-import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.convertMsgCount;
+import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
 
 @Component
 @Slf4j
@@ -66,13 +66,58 @@ public class SrmConverter {
     private Point processRequestorDescription(final RequestorDescription requestor, SrmProperties props) {
         RequestorPositionVector vector = requestor.getPosition();
 
+        if (vector != null) {
+
+
+            if (vector.getHeading() != null) {
+                props.setHeading(convertHeading(vector.getHeading().getValue()));
+            }
+
+            TransmissionAndSpeed tSpeed = vector.getSpeed();
+            if (tSpeed != null) {
+                Velocity speed = tSpeed.getSpeed();
+                if (speed != null) {
+                    props.setSpeed(convertSpeed(speed.getValue()));
+                }
+                TransmissionState transmission = tSpeed.getTransmisson();
+                if (transmission != null) {
+                    props.setTransmission(ProcessedTransmissionState.fromName(transmission.getName()));
+                }
+            }
+
+            Position3D position = vector.getPosition();
+            if (position != null) {
+                if (position.getLong_() != null) {
+                    props.setLongitude(convertLong(position.getLong_().getValue()));
+                }
+                if (position.getLat() != null) {
+                    props.setLatitude(convertLat(position.getLat().getValue()));
+                }
+                if (position.getElevation() != null) {
+                    props.setElevation(convertElevation(position.getElevation().getValue()));
+                }
+            }
+        }
+
         VehicleID id = requestor.getId();
+        props.setVehicleID(convertVehicleID(id));
+
         DescriptiveName name = requestor.getName();
+        if (name != null) {
+            props.setDescriptiveName(name.getValue());
+        }
         DescriptiveName routeName = requestor.getRouteName();
+
         TransitVehicleOccupancy occupancy = requestor.getTransitOccupancy();
         DeltaTime schedule = requestor.getTransitSchedule();
         TransitVehicleStatus status = requestor.getTransitStatus();
         RequestorType type = requestor.getType();
+
+        if (props.getLongitude() != null && props.getLatitude() != null) {
+            return new Point(props.getLongitude(), props.getLatitude());
+        } else {
+            return null;
+        }
     }
 
     private void processSignalRequestPackage(SignalRequestPackage pkg, SrmProperties props) {

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
@@ -1,0 +1,4 @@
+package us.dot.its.jpo.geojsonconverter.converter.srm;
+
+public class SrmConverter {
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
@@ -8,7 +8,6 @@ import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.*;
 import us.dot.its.jpo.geojsonconverter.pojos.ProcessedValidationMessage;
 import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedTransmissionState;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
-import us.dot.its.jpo.geojsonconverter.pojos.geojson.rtcm.RTCMProperties;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.*;
 import us.dot.its.jpo.geojsonconverter.utils.BitstringUtils;
 import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
@@ -101,7 +100,7 @@ public class SrmConverter {
             props.setTransitOccupancy(ProcessedTransitVehicleOccupancy.fromName(occupancy.getName()));
         }
 
-        props.setTransitSchedule(convertDeltaTime(requestor.getTransitSchedule()));
+        props.setTransitScheduleSeconds(convertDeltaTime(requestor.getTransitSchedule()));
 
         TransitVehicleStatus status = requestor.getTransitStatus();
         ProcessedTransitVehicleStatus processedStatus = new ProcessedTransitVehicleStatus();
@@ -121,7 +120,7 @@ public class SrmConverter {
             if (tSpeed != null) {
                 Velocity speed = tSpeed.getSpeed();
                 if (speed != null) {
-                    props.setSpeed(convertSpeed(speed.getValue()));
+                    props.setSpeedMetersPerSecond(convertSpeed(speed.getValue()));
                 }
                 TransmissionState transmission = tSpeed.getTransmisson();
                 if (transmission != null) {
@@ -183,7 +182,7 @@ public class SrmConverter {
         processed.setEstimatedTimeOfArrival(ts);
         if (pkg.getDuration() != null) {
             Duration duration = Duration.ofMillis(pkg.getDuration().getValue());
-            processed.setEstimatedTimeOfArrivalDuration(duration);
+            processed.setEstimatedTimeOfArrivalDurationSeconds(duration);
         }
     }
 

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
@@ -20,25 +20,25 @@ import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
 @Slf4j
 public class SrmConverter {
 
-    public List<ProcessedSrm> processSrm(final SignalRequestMessageMessageFrame ssmFrame) {
+    public ProcessedSrm processSrm(final SignalRequestMessageMessageFrame ssmFrame) {
         // We don't know what year it is; assume it is this year.
         var now = ZonedDateTime.now();
         return processSrm(ssmFrame, now.getYear());
     }
 
-    public List<ProcessedSrm> processSrm(final SignalRequestMessageMessageFrame srmFrame, final int year) {
+    public ProcessedSrm processSrm(final SignalRequestMessageMessageFrame srmFrame, final int year) {
         var list = new ArrayList<ProcessedSrm>();
 
         if (srmFrame == null) {
             log.error("MessageFrame is null");
-            return list;
+            return null;
         }
 
         SignalRequestMessage srm = srmFrame.getValue();
 
         if (srm == null) {
             log.error("SignalRequestMessage is null");
-            return list;
+            return null;
         }
 
         final Integer sequenceNumber = convertMsgCount(srm.getSequenceNumber());
@@ -47,25 +47,30 @@ public class SrmConverter {
         final ZonedDateTime timeStamp = convertMinuteOfYearAndDSecond(moy, year, dsec);
 
         RequestorDescription requestor = srm.getRequestor();
+        var props = new SrmProperties();
+        processRequestorDescription(requestor, props);
+        props.setTimeStamp(timeStamp);
+        props.setSequenceNumber(sequenceNumber);
 
         SignalRequestList requests = srm.getRequests();
+        List<ProcessedSignalRequest> processedRequests = new ArrayList<>();
         for (SignalRequestPackage pkg : requests) {
-            var props = new SrmProperties();
-            props.setTimeStamp(timeStamp);
-            props.setSequenceNumber(sequenceNumber);
-            processRequestorDescription(requestor, props);
-            processSignalRequestPackage(pkg, props, year);
-            Point geometry;
-            if (props.getLongitude() != null && props.getLatitude() != null) {
-                geometry = new Point(props.getLongitude(), props.getLatitude());
-            } else {
-                geometry = null;
-            }
-            var processed = new ProcessedSrm(geometry, props);
-            list.add(processed);
+            var processedSignalRequest = new ProcessedSignalRequest();
+            processSignalRequestPackage(pkg, processedSignalRequest, year);
+            processedRequests.add(processedSignalRequest);
         }
+        props.setRequests(processedRequests);
 
-        return list;
+        Point geometry;
+        if (props.getLongitude() != null && props.getLatitude() != null) {
+            geometry = new Point(props.getLongitude(), props.getLatitude());
+        } else {
+            geometry = null;
+        }
+        var processed = new ProcessedSrm(geometry, props);
+        list.add(processed);
+
+        return processed;
     }
 
     private void processRequestorDescription(final RequestorDescription requestor, SrmProperties props) {
@@ -134,46 +139,46 @@ public class SrmConverter {
         }
     }
 
-    private void processSignalRequestPackage(final SignalRequestPackage pkg, final SrmProperties props, final int year) {
+    private void processSignalRequestPackage(final SignalRequestPackage pkg, final ProcessedSignalRequest processed, final int year) {
         if (pkg == null) { return; }
-        processSignalRequest(pkg.getRequest(), props);
-        processETA(pkg, props, year);
+        processSignalRequest(pkg.getRequest(), processed);
+        processETA(pkg, processed, year);
     }
 
-    private void processSignalRequest(final SignalRequest request, final SrmProperties props) {
+    private void processSignalRequest(final SignalRequest request, final ProcessedSignalRequest processed) {
         if (request == null) return;
 
         RegionIntersectionId id = convertIntersectionReferenceID(request.getId());
-        props.setRegion(id.region());
-        props.setIntersectionId(id.intersectionId());
+        processed.setRegion(id.region());
+        processed.setIntersectionId(id.intersectionId());
 
         RequestID requestId = request.getRequestID();
         if (requestId != null) {
-            props.setRequestID((int)requestId.getValue());
+            processed.setRequestID((int)requestId.getValue());
         }
 
         PriorityRequestType requestType = request.getRequestType();
         if (requestType != null) {
-            props.setPriorityRequestType(ProcessedPriorityRequestType.fromName(requestType.getName()));
+            processed.setPriorityRequestType(ProcessedPriorityRequestType.fromName(requestType.getName()));
         }
 
         AccessPointID inbound = convertIntersectionAccessPointID(request.getInBoundLane());
-        props.setInboundLaneID(inbound.laneID());
-        props.setInboundApproachID(inbound.approachID());
-        props.setInboundLaneConnectionID(inbound.connectionID());
+        processed.setInboundLaneID(inbound.laneID());
+        processed.setInboundApproachID(inbound.approachID());
+        processed.setInboundLaneConnectionID(inbound.connectionID());
 
         AccessPointID outbound = convertIntersectionAccessPointID(request.getOutBoundLane());
-        props.setOutboundLaneID(outbound.laneID());
-        props.setOutboundApproachID(outbound.approachID());
-        props.setOutboundLaneConnectionID(outbound.connectionID());
+        processed.setOutboundLaneID(outbound.laneID());
+        processed.setOutboundApproachID(outbound.approachID());
+        processed.setOutboundLaneConnectionID(outbound.connectionID());
     }
 
-    private void processETA(final SignalRequestPackage pkg, final SrmProperties props, final int year) {
+    private void processETA(final SignalRequestPackage pkg, final ProcessedSignalRequest processed, final int year) {
         ZonedDateTime ts = convertMinuteOfYearAndDSecond( pkg.getMinute(), year, pkg.getSecond());
-        props.setEstimatedTimeOfArrival(ts);
+        processed.setEstimatedTimeOfArrival(ts);
         if (pkg.getDuration() != null) {
             Duration duration = Duration.ofMillis(pkg.getDuration().getValue());
-            props.setEstimatedTimeOfArrivalDuration(duration);
+            processed.setEstimatedTimeOfArrivalDuration(duration);
         }
     }
 

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopology.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopology.java
@@ -1,4 +1,58 @@
 package us.dot.its.jpo.geojsonconverter.converter.srm;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import us.dot.its.jpo.geojsonconverter.partitioner.IntersectionIdPartitioner;
+import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
+import us.dot.its.jpo.geojsonconverter.pojos.common.DeserializedRawMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
+import us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes;
+import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
+import us.dot.its.jpo.geojsonconverter.validator.SrmJsonValidator;
+
+import static us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes.OdeMessageFrame;
+import static us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes.RsuIntersectionKey;
+
+@Slf4j
 public class SrmTopology {
+
+    public static Topology build(
+            String srmOdeJsonTopic,
+            String srmProcessedJsonTopic,
+            SrmJsonValidator srmJsonValidator,
+            SrmConverter converter) {
+        var builder = new StreamsBuilder();
+
+        builder
+                .stream(srmOdeJsonTopic, Consumed.with(Serdes.Void(), Serdes.Bytes()))
+                .mapValues((Void key, Bytes value) -> {
+                    var rawMessageFrame = new DeserializedRawMessageFrame();
+                    try (var serdes = OdeMessageFrame()) {
+                        JsonValidatorResult validationResults = srmJsonValidator.validate(value.get());
+                        rawMessageFrame.setOdeMessageFrameData(
+                                serdes.deserializer().deserialize(srmOdeJsonTopic, value.get()));
+                        rawMessageFrame.setValidationResults(validationResults);
+                        log.debug(validationResults.describeResults());
+                    } catch (Exception e) {
+                        JsonValidatorResult validatorResult = new JsonValidatorResult();
+                        validatorResult.addException(e);
+                        rawMessageFrame.setValidationResults(validatorResult);
+                        rawMessageFrame.setValidationFailure(true);
+                        rawMessageFrame.setFailedMessage(e.getMessage());
+                        log.error("Error in SSM validation: ", e);
+                    }
+                    return rawMessageFrame;
+                })
+                .flatMap(new SrmTransformer(converter))
+                .to(srmProcessedJsonTopic,
+                        Produced.with(RsuIntersectionKey(),
+                                JsonSerdes.ProcessedSrm(),
+                                new IntersectionIdPartitioner<RsuIntersectionKey, ProcessedSrm>()));
+        return builder.build();
+    }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopology.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopology.java
@@ -48,7 +48,7 @@ public class SrmTopology {
                     }
                     return rawMessageFrame;
                 })
-                .flatMap(new SrmTransformer(converter))
+                .map(new SrmTransformer(converter))
                 .to(srmProcessedJsonTopic,
                         Produced.with(RsuIntersectionKey(),
                                 JsonSerdes.ProcessedSrm(),

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopology.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopology.java
@@ -7,8 +7,8 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
-import us.dot.its.jpo.geojsonconverter.partitioner.IntersectionIdPartitioner;
-import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
+import us.dot.its.jpo.geojsonconverter.partitioner.RsuIdPartitioner;
+import us.dot.its.jpo.geojsonconverter.partitioner.RsuVehicleIdKey;
 import us.dot.its.jpo.geojsonconverter.pojos.common.DeserializedRawMessageFrame;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
 import us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes;
@@ -16,7 +16,7 @@ import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
 import us.dot.its.jpo.geojsonconverter.validator.SrmJsonValidator;
 
 import static us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes.OdeMessageFrame;
-import static us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes.RsuIntersectionKey;
+import static us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes.RsuVehicleIdKey;
 
 @Slf4j
 public class SrmTopology {
@@ -50,9 +50,9 @@ public class SrmTopology {
                 })
                 .map(new SrmTransformer(converter))
                 .to(srmProcessedJsonTopic,
-                        Produced.with(RsuIntersectionKey(),
+                        Produced.with(RsuVehicleIdKey(),
                                 JsonSerdes.ProcessedSrm(),
-                                new IntersectionIdPartitioner<RsuIntersectionKey, ProcessedSrm>()));
+                                new RsuIdPartitioner<RsuVehicleIdKey, ProcessedSrm>()));
         return builder.build();
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopology.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopology.java
@@ -1,0 +1,4 @@
+package us.dot.its.jpo.geojsonconverter.converter.srm;
+
+public class SrmTopology {
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
@@ -4,13 +4,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame;
-import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuVehicleIdKey;
 import us.dot.its.jpo.geojsonconverter.pojos.common.DeserializedRawMessageFrame;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
 import us.dot.its.jpo.geojsonconverter.utils.ProcessedSchemaVersions;
-import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
 import us.dot.its.jpo.ode.model.OdeMessageFrameData;
 import us.dot.its.jpo.ode.model.OdeMessageFrameMetadata;
 import us.dot.its.jpo.ode.model.OdeMessageFramePayload;
@@ -19,7 +17,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.*;
 
 /**
  * KeyValueMapper that converts a keyless stream of SRM MessageFrames to a Key-Value Pair.
@@ -74,10 +71,9 @@ public class SrmTransformer
     private KeyValue<RsuVehicleIdKey, ProcessedSrm> createProcessedSrm(
             SignalRequestMessageMessageFrame srm, OdeMessageFrameMetadata metadata) {
         final ZonedDateTime odeReceivedAt = Instant.parse(metadata.getOdeReceivedAt()).atZone(ZoneId.of("UTC"));
-        final int year = odeReceivedAt.getYear();
 
         // Process message frame
-        ProcessedSrm processedSrm =  converter.processSrm(srm, year);
+        ProcessedSrm processedSrm =  converter.processSrm(srm, odeReceivedAt);
 
         // Add metadata
         SrmProperties properties = processedSrm.getProperties();

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
@@ -1,11 +1,11 @@
 package us.dot.its.jpo.geojsonconverter.converter.srm;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
+import us.dot.its.jpo.geojsonconverter.partitioner.RsuVehicleIdKey;
 import us.dot.its.jpo.geojsonconverter.pojos.common.DeserializedRawMessageFrame;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
@@ -20,9 +20,20 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+/**
+ * KeyValueMapper that converts a keyless stream of SRM MessageFrames to a Key-Value Pair.
+ * <dl>
+ *     <dh>Key</dh>
+ *     <dd>RsuVehicleIdKey - The key contains the RSU ID and Vehicle ID. Note we don't use
+ *     IntersectionId/Region in the key, because in the most general case a ProcessedSrm7 can have
+ *     multiple requests with different IntersectionIDs</dd>
+ *     <dh>Value</dh>
+ *     <dd>A {@link ProcessedSrm}</dd>
+ * </dl>>
+ */
 @Slf4j
 public class SrmTransformer
-    implements KeyValueMapper<Void, DeserializedRawMessageFrame, KeyValue<RsuIntersectionKey, ProcessedSrm>> {
+    implements KeyValueMapper<Void, DeserializedRawMessageFrame, KeyValue<RsuVehicleIdKey, ProcessedSrm>> {
 
     private final SrmConverter converter;
 
@@ -31,7 +42,7 @@ public class SrmTransformer
     }
 
     @Override
-    public KeyValue<RsuIntersectionKey, ProcessedSrm> apply(Void rawKey, DeserializedRawMessageFrame rawSrm) {
+    public KeyValue<RsuVehicleIdKey, ProcessedSrm> apply(Void rawKey, DeserializedRawMessageFrame rawSrm) {
         try {
             if (!rawSrm.isValidationFailure()) {
                 OdeMessageFrameData rawValue = rawSrm.getOdeMessageFrameData();
@@ -44,10 +55,12 @@ public class SrmTransformer
         } catch (Exception e) {
             log.error("Error converting SRM to Processed SRM", e);
         }
-        return new ArrayList<>();
+        var key = new RsuVehicleIdKey();
+        key.setRsuId("ERROR");
+        return KeyValue.pair(key, null);
     }
 
-    private KeyValue<RsuIntersectionKey, ProcessedSrm> createProcessedSrm(
+    private KeyValue<RsuVehicleIdKey, ProcessedSrm> createProcessedSrm(
             SignalRequestMessageMessageFrame srm, OdeMessageFrameMetadata metadata, JsonValidatorResult validationResults) {
         final ZonedDateTime odeReceivedAt = Instant.parse(metadata.getOdeReceivedAt()).atZone(ZoneId.of("UTC"));
         final int year = odeReceivedAt.getYear();
@@ -65,30 +78,9 @@ public class SrmTransformer
         properties.setOriginIp(originIp);
         properties.setSchemaVersion(ProcessedSchemaVersions.PROCESSED_SSM_SCHEMA_VERSION);
 
-        var requests = properties.getRequests();
-        RsuIntersectionKey key = null;
-        if (requests != null && !requests.isEmpty()) {
-            SortedSet<RsuIntersectionKey> keySet = new TreeSet<>();
-            requests.forEach(request ->
-                    keySet.add(
-                            new RsuIntersectionKey(
-                                    originIp,
-                                    request.getIntersectionId(),
-                                    request.getRegion())));
-
-            key = keySet.first();
-
-            // Warn if the requests are for more than one intersection
-            if (keySet.size() > 1) {
-                log.warn("The ProcessedSrm contains requests for more than one intersection: {}.  " +
-                        "Using {} as the topic key.  Topologies that consume this topic will need to repartition  to" +
-                        "perform intersection-based joins.", StringUtils.join(keySet, ", "), key);
-            }
-        } else {
-            key = new RsuIntersectionKey();
-            key.setRsuId(originIp);
-            log.warn("The ProcessedSrm has no requests {}", processedSrm);
-        }
+        // Note we don't use IntersectionId/Region in the key, because in the most general case the ProcessedSrm have
+        // multiple requests with different IntersectionIDs
+        RsuVehicleIdKey key = new RsuVehicleIdKey(properties.getOriginIp(), properties.getVehicleID());
 
        return new KeyValue<>(key, processedSrm);
     }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
@@ -1,6 +1,7 @@
 package us.dot.its.jpo.geojsonconverter.converter.srm;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame;
@@ -17,12 +18,11 @@ import us.dot.its.jpo.ode.model.OdeMessageFramePayload;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @Slf4j
 public class SrmTransformer
-    implements KeyValueMapper<Void, DeserializedRawMessageFrame, Iterable<KeyValue<RsuIntersectionKey, ProcessedSrm>>> {
+    implements KeyValueMapper<Void, DeserializedRawMessageFrame, KeyValue<RsuIntersectionKey, ProcessedSrm>> {
 
     private final SrmConverter converter;
 
@@ -31,7 +31,7 @@ public class SrmTransformer
     }
 
     @Override
-    public Iterable<KeyValue<RsuIntersectionKey, ProcessedSrm>> apply(Void rawKey, DeserializedRawMessageFrame rawSrm) {
+    public KeyValue<RsuIntersectionKey, ProcessedSrm> apply(Void rawKey, DeserializedRawMessageFrame rawSrm) {
         try {
             if (!rawSrm.isValidationFailure()) {
                 OdeMessageFrameData rawValue = rawSrm.getOdeMessageFrameData();
@@ -39,7 +39,7 @@ public class SrmTransformer
                 OdeMessageFramePayload payload = rawValue.getPayload();
                 SignalRequestMessageMessageFrame ssmMessageFrame = (SignalRequestMessageMessageFrame)payload.getData();
                 JsonValidatorResult validationResults = rawSrm.getValidationResults();
-                return createProcessedSrmList(ssmMessageFrame, metadata, validationResults);
+                return createProcessedSrm(ssmMessageFrame, metadata, validationResults);
             }
         } catch (Exception e) {
             log.error("Error converting SRM to Processed SRM", e);
@@ -47,32 +47,49 @@ public class SrmTransformer
         return new ArrayList<>();
     }
 
-    private List<KeyValue<RsuIntersectionKey, ProcessedSrm>> createProcessedSrmList(
+    private KeyValue<RsuIntersectionKey, ProcessedSrm> createProcessedSrm(
             SignalRequestMessageMessageFrame srm, OdeMessageFrameMetadata metadata, JsonValidatorResult validationResults) {
         final ZonedDateTime odeReceivedAt = Instant.parse(metadata.getOdeReceivedAt()).atZone(ZoneId.of("UTC"));
         final int year = odeReceivedAt.getYear();
 
         // Process message frame
-        var processedSrmList =  converter.processSrm(srm, year);
+        ProcessedSrm processedSrm =  converter.processSrm(srm, year);
 
         List<KeyValue<RsuIntersectionKey, ProcessedSrm>> keyValueList = new ArrayList<>();
 
         // Add metadata
-        for (ProcessedSrm processedSrm : processedSrmList) {
-            SrmProperties properties = processedSrm.getProperties();
-            properties.setOdeReceivedAt(odeReceivedAt);
-            properties.setAsn1(metadata.getAsn1());
-            properties.setOriginIp(metadata.getOriginIp());
-            properties.setSchemaVersion(ProcessedSchemaVersions.PROCESSED_SSM_SCHEMA_VERSION);
+        SrmProperties properties = processedSrm.getProperties();
+        properties.setOdeReceivedAt(odeReceivedAt);
+        properties.setAsn1(metadata.getAsn1());
+        final String originIp = metadata.getOriginIp();
+        properties.setOriginIp(originIp);
+        properties.setSchemaVersion(ProcessedSchemaVersions.PROCESSED_SSM_SCHEMA_VERSION);
 
-            var key = new RsuIntersectionKey();
-            key.setRsuId(metadata.getOriginIp());
-            key.setIntersectionId(properties.getIntersectionId());
-            key.setRegion(properties.getRegion());
+        var requests = properties.getRequests();
+        RsuIntersectionKey key = null;
+        if (requests != null && !requests.isEmpty()) {
+            SortedSet<RsuIntersectionKey> keySet = new TreeSet<>();
+            requests.forEach(request ->
+                    keySet.add(
+                            new RsuIntersectionKey(
+                                    originIp,
+                                    request.getIntersectionId(),
+                                    request.getRegion())));
 
-            keyValueList.add(new KeyValue<>(key, processedSrm));
+            key = keySet.first();
+
+            // Warn if the requests are for more than one intersection
+            if (keySet.size() > 1) {
+                log.warn("The ProcessedSrm contains requests for more than one intersection: {}.  " +
+                        "Using {} as the topic key.  Topologies that consume this topic will need to repartition  to" +
+                        "perform intersection-based joins.", StringUtils.join(keySet, ", "), key);
+            }
+        } else {
+            key = new RsuIntersectionKey();
+            key.setRsuId(originIp);
+            log.warn("The ProcessedSrm has no requests {}", processedSrm);
         }
 
-        return keyValueList;
+       return new KeyValue<>(key, processedSrm);
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
@@ -17,6 +17,7 @@ import us.dot.its.jpo.ode.model.OdeMessageFramePayload;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.*;
 
@@ -49,8 +50,18 @@ public class SrmTransformer
                 OdeMessageFrameMetadata metadata = rawValue.getMetadata();
                 OdeMessageFramePayload payload = rawValue.getPayload();
                 SignalRequestMessageMessageFrame ssmMessageFrame = (SignalRequestMessageMessageFrame)payload.getData();
-                JsonValidatorResult validationResults = rawSrm.getValidationResults();
-                return createProcessedSrm(ssmMessageFrame, metadata, validationResults);
+                KeyValue<RsuVehicleIdKey, ProcessedSrm> processedSrm = createProcessedSrm(ssmMessageFrame, metadata);
+                converter.jsonValidation(processedSrm.value.getProperties(), rawSrm.getValidationResults());
+                return processedSrm;
+            } else {
+                var processed = new ProcessedSrm(null, new SrmProperties());
+                ZonedDateTime utcDateTime = ZonedDateTime.now(ZoneOffset.UTC);
+                processed.getProperties().setOdeReceivedAt(utcDateTime);
+                converter.jsonValidation(processed.getProperties(), rawSrm.getValidationResults());
+                processed.getProperties().addValidationMessage(rawSrm.getFailedMessage());
+                RsuVehicleIdKey key = new RsuVehicleIdKey();
+                key.setRsuId("ERROR");
+                return KeyValue.pair(key, processed);
             }
         } catch (Exception e) {
             log.error("Error converting SRM to Processed SRM", e);
@@ -61,14 +72,12 @@ public class SrmTransformer
     }
 
     private KeyValue<RsuVehicleIdKey, ProcessedSrm> createProcessedSrm(
-            SignalRequestMessageMessageFrame srm, OdeMessageFrameMetadata metadata, JsonValidatorResult validationResults) {
+            SignalRequestMessageMessageFrame srm, OdeMessageFrameMetadata metadata) {
         final ZonedDateTime odeReceivedAt = Instant.parse(metadata.getOdeReceivedAt()).atZone(ZoneId.of("UTC"));
         final int year = odeReceivedAt.getYear();
 
         // Process message frame
         ProcessedSrm processedSrm =  converter.processSrm(srm, year);
-
-        List<KeyValue<RsuIntersectionKey, ProcessedSrm>> keyValueList = new ArrayList<>();
 
         // Add metadata
         SrmProperties properties = processedSrm.getProperties();

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
@@ -1,0 +1,6 @@
+package us.dot.its.jpo.geojsonconverter.converter.srm;
+
+import org.apache.kafka.streams.kstream.Transformer;
+
+public class SrmTransformer {
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTransformer.java
@@ -1,6 +1,78 @@
 package us.dot.its.jpo.geojsonconverter.converter.srm;
 
-import org.apache.kafka.streams.kstream.Transformer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame;
+import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
+import us.dot.its.jpo.geojsonconverter.pojos.common.DeserializedRawMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
+import us.dot.its.jpo.geojsonconverter.utils.ProcessedSchemaVersions;
+import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
+import us.dot.its.jpo.ode.model.OdeMessageFrameData;
+import us.dot.its.jpo.ode.model.OdeMessageFrameMetadata;
+import us.dot.its.jpo.ode.model.OdeMessageFramePayload;
 
-public class SrmTransformer {
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class SrmTransformer
+    implements KeyValueMapper<Void, DeserializedRawMessageFrame, Iterable<KeyValue<RsuIntersectionKey, ProcessedSrm>>> {
+
+    private final SrmConverter converter;
+
+    public SrmTransformer(SrmConverter converter) {
+        this.converter = converter;
+    }
+
+    @Override
+    public Iterable<KeyValue<RsuIntersectionKey, ProcessedSrm>> apply(Void rawKey, DeserializedRawMessageFrame rawSrm) {
+        try {
+            if (!rawSrm.isValidationFailure()) {
+                OdeMessageFrameData rawValue = rawSrm.getOdeMessageFrameData();
+                OdeMessageFrameMetadata metadata = rawValue.getMetadata();
+                OdeMessageFramePayload payload = rawValue.getPayload();
+                SignalRequestMessageMessageFrame ssmMessageFrame = (SignalRequestMessageMessageFrame)payload.getData();
+                JsonValidatorResult validationResults = rawSrm.getValidationResults();
+                return createProcessedSrmList(ssmMessageFrame, metadata, validationResults);
+            }
+        } catch (Exception e) {
+            log.error("Error converting SRM to Processed SRM", e);
+        }
+        return new ArrayList<>();
+    }
+
+    private List<KeyValue<RsuIntersectionKey, ProcessedSrm>> createProcessedSrmList(
+            SignalRequestMessageMessageFrame srm, OdeMessageFrameMetadata metadata, JsonValidatorResult validationResults) {
+        final ZonedDateTime odeReceivedAt = Instant.parse(metadata.getOdeReceivedAt()).atZone(ZoneId.of("UTC"));
+        final int year = odeReceivedAt.getYear();
+
+        // Process message frame
+        var processedSrmList =  converter.processSrm(srm, year);
+
+        List<KeyValue<RsuIntersectionKey, ProcessedSrm>> keyValueList = new ArrayList<>();
+
+        // Add metadata
+        for (ProcessedSrm processedSrm : processedSrmList) {
+            SrmProperties properties = processedSrm.getProperties();
+            properties.setOdeReceivedAt(odeReceivedAt);
+            properties.setAsn1(metadata.getAsn1());
+            properties.setOriginIp(metadata.getOriginIp());
+            properties.setSchemaVersion(ProcessedSchemaVersions.PROCESSED_SSM_SCHEMA_VERSION);
+
+            var key = new RsuIntersectionKey();
+            key.setRsuId(metadata.getOriginIp());
+            key.setIntersectionId(properties.getIntersectionId());
+            key.setRegion(properties.getRegion());
+
+            keyValueList.add(new KeyValue<>(key, processedSrm));
+        }
+
+        return keyValueList;
+    }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
@@ -1,16 +1,20 @@
 package us.dot.its.jpo.geojsonconverter.converter.ssm;
 
+import com.networknt.schema.ValidationMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import us.dot.its.jpo.asn.j2735.r2024.Common.*;
 import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.*;
+import us.dot.its.jpo.geojsonconverter.pojos.ProcessedValidationMessage;
 import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedPrioritizationResponseStatus;
 import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSignalStatus;
 import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
@@ -161,6 +165,29 @@ public class SsmConverter {
             processed.setRequesterIso3833VehicleType((int)iso.getValue());
         }
         processed.setRequestImportanceLevel(convertRequestImportanceLevel(requestorType.getRequest()));
+    }
+
+    /**
+     * Add JSON schema validation results for J2735 and Metadata validation.
+     * @param properties The properties to add validation messages to
+     * @param validatorResult the schema validator result
+     */
+    public void jsonValidation(ProcessedSsm properties, JsonValidatorResult validatorResult) {
+        var messages = new ArrayList<ProcessedValidationMessage>();
+        for (Exception exception : validatorResult.getExceptions()) {
+            var msg = new ProcessedValidationMessage();
+            msg.setMessage(exception.getMessage());
+            msg.setException(Arrays.toString(exception.getStackTrace()));
+            messages.add(msg);
+        }
+        for (ValidationMessage vm : validatorResult.getValidationMessages()) {
+            var msg = new ProcessedValidationMessage();
+            msg.setMessage(vm.getMessage());
+            msg.setSchemaPath(vm.getSchemaPath());
+            msg.setJsonPath(vm.getPath());
+            messages.add(msg);
+        }
+        properties.addValidationMessages(messages);
     }
 
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
@@ -4,11 +4,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import us.dot.its.jpo.asn.j2735.r2024.Common.*;
 import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.*;
-import us.dot.its.jpo.geojsonconverter.converter.FieldConversions;
+import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedPrioritizationResponseStatus;
 import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +19,7 @@ import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
 public class SsmConverter {
 
     public List<ProcessedSsm> processedSsm(final SignalStatusMessageMessageFrame ssmFrame) {
-        // We don't know what year it is, assume the time is now
+        // We don't know what year it is; assume it is this year.
         var now = ZonedDateTime.now();
         return processSsm(ssmFrame, now.getYear());
     }
@@ -61,19 +60,69 @@ public class SsmConverter {
                 processed.setStatusSequenceNumber(statusSequenceNumber);
                 processed.setRegion(regInt.region());
                 processed.setIntersectionId(regInt.intersectionId());
-                processSignalStatusPackage(pkg, processed);
+                processSignalStatusPackage(pkg, processed,year);
                 list.add(processed);
             }
         }
+        return list;
     }
+
 
     private void processSignalStatusPackage(final SignalStatusPackage pkg, final ProcessedSsm processed, final int year) {
 
         SignalRequesterInfo requester = pkg.getRequester();
+        processRequester(requester, processed);
+
         IntersectionAccessPoint inboundOn = pkg.getInboundOn();
         IntersectionAccessPoint outboundOn = pkg.getOutboundOn();
+        processAccessPoints(inboundOn, outboundOn, processed);
+
+        PrioritizationResponseStatus status = pkg.getStatus();
+        if (status != null && status.getName() != null) {
+            ProcessedPrioritizationResponseStatus processedStatus
+                    = ProcessedPrioritizationResponseStatus.fromName(status.getName());
+            processed.setStatus(processedStatus);
+        }
 
         // ETA
+        processETA(pkg, processed, year);
+
+    }
+
+    private void processRequester(final SignalRequesterInfo requester, final ProcessedSsm processed) {
+        VehicleID vehicleId = requester.getId();
+        processed.setVehicleID(convertVehicleID(vehicleId));
+
+        MsgCount requestSequenceNumber = requester.getSequenceNumber();
+        processed.setRequesterSequenceNumber(convertMsgCount(requestSequenceNumber));
+
+        RequestID requestId = requester.getRequest();
+        if (requestId != null) {
+            processed.setRequestID((int)requestId.getValue());
+        }
+
+        processed.setRequesterRole(convertBasicVehicleRole(requester.getRole()));
+
+        RequestorType requestorType = requester.getTypeData();
+        processRequestorType(requestorType, processed);
+    }
+
+    private void processAccessPoints(final IntersectionAccessPoint inboundOn, final IntersectionAccessPoint outboundOn,
+                                     ProcessedSsm processed) {
+        var inbound = convertIntersectionAccessPointID(inboundOn);
+        processed.setInboundOnLaneID(inbound.laneID());
+        processed.setInboundOnApproachID(inbound.approachID());
+        processed.setInboundOnLaneConnectionID(inbound.connectionID());
+
+        var outbound = convertIntersectionAccessPointID(outboundOn);
+        processed.setOutboundOnLaneID(outbound.laneID());
+        processed.setOutboundOnApproachID(outbound.approachID());
+        processed.setOutboundOnLaneConnectionID(outbound.connectionID());
+    }
+
+
+
+    private void processETA(final SignalStatusPackage pkg, final ProcessedSsm processed, final int year) {
         MinuteOfTheYear moy = pkg.getMinute();
         DSecond dsec = pkg.getSecond();
         ZonedDateTime ts = convertMinuteOfYearAndDSecond(moy, year, dsec);
@@ -82,11 +131,23 @@ public class SsmConverter {
             Duration duration = Duration.ofMillis(pkg.getDuration().getValue());
             processed.setEstimatedTimeOfArrivalDuration(duration);
         }
-
-        PrioritizationResponseStatus status = pkg.getStatus();
-
-
-
-
     }
+
+
+
+    private void processRequestorType(final RequestorType requestorType, final ProcessedSsm processed) {
+        // Use this role if top-level role is missing
+        if (processed.getRequesterRole() == null) {
+            processed.setRequesterRole(convertBasicVehicleRole(requestorType.getRole()));
+        }
+        processed.setRequesterSubrole(convertRequestSubRole(requestorType.getSubrole()));
+        processed.setRequesterHpmsType(convertVehicleType(requestorType.getHpmsType()));
+        Iso3833VehicleType iso = requestorType.getIso3883();
+        if (iso != null) {
+            processed.setRequesterIso3833VehicleType((int)iso.getValue());
+        }
+        RequestImportanceLevel request = requestorType.getRequest();
+        processed.setRequestImportanceLevel(convertRequestImportanceLevel(request));
+    }
+
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import us.dot.its.jpo.asn.j2735.r2024.Common.*;
 import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.*;
 import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedPrioritizationResponseStatus;
+import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSignalStatus;
 import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
 
 import java.time.Duration;
@@ -18,57 +19,79 @@ import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
 @Slf4j
 public class SsmConverter {
 
-    public List<ProcessedSsm> processSsm(final SignalStatusMessageMessageFrame ssmFrame) {
+    public ProcessedSsm processSsm(final SignalStatusMessageMessageFrame ssmFrame) {
         // We don't know what year it is; assume it is this year.
         var now = ZonedDateTime.now();
         return processSsm(ssmFrame, now.getYear());
     }
 
-    public List<ProcessedSsm> processSsm(final SignalStatusMessageMessageFrame ssmFrame, final int year) {
-        var list = new ArrayList<ProcessedSsm>();
-
-
+    public ProcessedSsm processSsm(final SignalStatusMessageMessageFrame ssmFrame, final int year) {
         if (ssmFrame == null) {
             log.error("SSM Message Frame is null");
-            return list;
+            return null;
         }
 
         SignalStatusMessage ssm = ssmFrame.getValue();
 
         if (ssm == null) {
             log.error("SignalStatusMessage is null");
-            return list;
+            return null;
         }
 
+        ProcessedSsm processedSsm = new ProcessedSsm();
+
         final Integer sequenceNumber = convertMsgCount(ssm.getSequenceNumber());
+        processedSsm.setSequenceNumber(sequenceNumber);
 
         MinuteOfTheYear moy = ssm.getTimeStamp();
         DSecond dsec = ssm.getSecond();
         final ZonedDateTime timeStamp = convertMinuteOfYearAndDSecond(moy, year, dsec);
+        processedSsm.setTimeStamp(timeStamp);
 
         SignalStatusList sslist = ssm.getStatus();
-        if (sslist == null) return list;
-        for (var status : sslist) {
-            final Integer statusSequenceNumber = convertMsgCount(status.getSequenceNumber());
-            final RegionIntersectionId regInt = convertIntersectionReferenceID(status.getId());
-            SignalStatusPackageList packageList = status.getSigStatus();
-            if (packageList == null) continue;
-            for (SignalStatusPackage pkg : packageList) {
-                var processed = new ProcessedSsm();
-                processed.setSequenceNumber(sequenceNumber);
-                processed.setTimeStamp(timeStamp);
-                processed.setStatusSequenceNumber(statusSequenceNumber);
-                processed.setRegion(regInt.region());
-                processed.setIntersectionId(regInt.intersectionId());
-                processSignalStatusPackage(pkg, processed,year);
-                list.add(processed);
-            }
+        if (sslist == null) {
+            log.error("SignalStatusList is null");
+            return processedSsm;
         }
-        return list;
+
+        if (sslist.size() > 0) {
+            SignalStatus signalStatus = sslist.getFirst();
+            final Integer statusSequenceNumber = convertMsgCount(signalStatus.getSequenceNumber());
+            final RegionIntersectionId regInt = convertIntersectionReferenceID(signalStatus.getId());
+
+            processedSsm.setStatusSequenceNumber(statusSequenceNumber);
+            processedSsm.setRegion(regInt.region());
+            processedSsm.setIntersectionId(regInt.intersectionId());
+
+            SignalStatusPackageList packageList = signalStatus.getSigStatus();
+            if (packageList == null) {
+                log.error("SignalStatusPackageList is null");
+                return processedSsm;
+            }
+
+            List<ProcessedSignalStatus> processedSignalStatusList = new ArrayList<>();
+            for (SignalStatusPackage pkg : packageList) {
+                var processed = new ProcessedSignalStatus();
+                processSignalStatusPackage(pkg, processed, year);
+                processedSignalStatusList.add(processed);
+            }
+            processedSsm.setStatusList(processedSignalStatusList);
+
+            // Warn if more than one intersection in SSM
+            if (sslist.size() > 1) {
+                log.warn("There is more than one intersection in the SSM.  This is unsupported.  The ProcessedSsm only " +
+                        "contains the first intersection: {}", ssmFrame);
+            }
+        } else {
+            // Abnormal case: no intersections
+            log.error("The SignalStatusList is empty");
+        }
+
+        return processedSsm;
     }
 
 
-    private void processSignalStatusPackage(final SignalStatusPackage pkg, final ProcessedSsm processed, final int year) {
+    private void processSignalStatusPackage(final SignalStatusPackage pkg, final ProcessedSignalStatus processed, final int year) {
         if (pkg == null) { return; }
         SignalRequesterInfo requester = pkg.getRequester();
         processRequester(requester, processed);
@@ -95,7 +118,7 @@ public class SsmConverter {
 
     }
 
-    private void processRequester(final SignalRequesterInfo requester, final ProcessedSsm processed) {
+    private void processRequester(final SignalRequesterInfo requester, final ProcessedSignalStatus processed) {
         if (requester == null) { return; }
         VehicleID vehicleId = requester.getId();
         processed.setVehicleID(convertVehicleID(vehicleId));
@@ -115,7 +138,7 @@ public class SsmConverter {
     }
 
 
-    private void processETA(final SignalStatusPackage pkg, final ProcessedSsm processed, final int year) {
+    private void processETA(final SignalStatusPackage pkg, final ProcessedSignalStatus processed, final int year) {
         if (pkg == null) { return; }
         ZonedDateTime ts = convertMinuteOfYearAndDSecond(pkg.getMinute(), year, pkg.getSecond());
         processed.setEstimatedTimeOfArrival(ts);
@@ -125,7 +148,7 @@ public class SsmConverter {
         }
     }
 
-    private void processRequestorType(final RequestorType requestorType, final ProcessedSsm processed) {
+    private void processRequestorType(final RequestorType requestorType, final ProcessedSignalStatus processed) {
         // Use this role if top-level role is missing
         if (requestorType == null) { return; }
         if (processed.getRequesterRole() == null) {

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
@@ -1,0 +1,4 @@
+package us.dot.its.jpo.geojsonconverter.converter.ssm;
+
+public class SsmConverter {
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
@@ -148,7 +148,7 @@ public class SsmConverter {
         processed.setEstimatedTimeOfArrival(ts);
         if (pkg.getDuration() != null) {
             Duration duration = Duration.ofMillis(pkg.getDuration().getValue());
-            processed.setEstimatedTimeOfArrivalDuration(duration);
+            processed.setEstimatedTimeOfArrivalDurationSeconds(duration);
         }
     }
 

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
@@ -1,4 +1,43 @@
 package us.dot.its.jpo.geojsonconverter.converter.ssm;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import us.dot.its.jpo.asn.j2735.r2024.Common.DSecond;
+import us.dot.its.jpo.asn.j2735.r2024.Common.MinuteOfTheYear;
+import us.dot.its.jpo.asn.j2735.r2024.Common.MsgCount;
+import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusList;
+import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessage;
+import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+
+@Component
+@Slf4j
 public class SsmConverter {
+
+    public ProcessedSsm processSsm(final SignalStatusMessageMessageFrame ssmFrame) {
+        var processed = new ProcessedSsm();
+
+        if (ssmFrame == null) {
+            log.error("SSM Message Frame is null");
+            return processed;
+        }
+
+        SignalStatusMessage ssm = ssmFrame.getValue();
+
+        if (ssm == null) {
+            log.error("SignalStatusMessage is null");
+            return processed;
+        }
+
+        MsgCount sequenceNumber = ssm.getSequenceNumber();
+        if (sequenceNumber != null) {
+            processed.setSequenceNumber((int)sequenceNumber.getValue());
+        }
+
+        MinuteOfTheYear moy = ssm.getTimeStamp();
+        DSecond dsec = ssm.getSecond();
+
+        SignalStatusList sslist = ssm.getStatus();
+
+    }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
@@ -12,6 +12,8 @@ import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
 import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,13 +25,21 @@ import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
 @Slf4j
 public class SsmConverter {
 
+
+
     public ProcessedSsm processSsm(final SignalStatusMessageMessageFrame ssmFrame) {
-        // We don't know what year it is; assume it is this year.
+        // We don't know what year it is; pass in the current time as a basis to guess the year.
         var now = ZonedDateTime.now();
-        return processSsm(ssmFrame, now.getYear());
+        return processSsm(ssmFrame, now);
     }
 
-    public ProcessedSsm processSsm(final SignalStatusMessageMessageFrame ssmFrame, final int year) {
+    /**
+     * Process an SSM MessageFrame
+     * @param ssmFrame SSM Message Frame
+     * @param ingestTime The message ingest time to use to guess the year
+     * @return the ProcessedSsm
+     */
+    public ProcessedSsm processSsm(final SignalStatusMessageMessageFrame ssmFrame, final ZonedDateTime ingestTime) {
         if (ssmFrame == null) {
             log.error("SSM Message Frame is null");
             return null;
@@ -49,7 +59,9 @@ public class SsmConverter {
 
         MinuteOfTheYear moy = ssm.getTimeStamp();
         DSecond dsec = ssm.getSecond();
-        final ZonedDateTime timeStamp = convertMinuteOfYearAndDSecond(moy, year, dsec);
+
+        final ZonedDateTime timeStamp = convertMinuteOfYearAndDSecond(moy, ingestTime, dsec);
+        final int year = timeStamp != null ? timeStamp.getYear() : ZonedDateTime.now(ZoneOffset.UTC).getYear();
         processedSsm.setTimeStamp(timeStamp);
 
         SignalStatusList sslist = ssm.getStatus();

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
@@ -18,7 +18,7 @@ import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
 @Slf4j
 public class SsmConverter {
 
-    public List<ProcessedSsm> processedSsm(final SignalStatusMessageMessageFrame ssmFrame) {
+    public List<ProcessedSsm> processSsm(final SignalStatusMessageMessageFrame ssmFrame) {
         // We don't know what year it is; assume it is this year.
         var now = ZonedDateTime.now();
         return processSsm(ssmFrame, now.getYear());

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
@@ -73,12 +73,18 @@ public class SsmConverter {
         SignalRequesterInfo requester = pkg.getRequester();
         processRequester(requester, processed);
 
-        IntersectionAccessPoint inboundOn = pkg.getInboundOn();
-        IntersectionAccessPoint outboundOn = pkg.getOutboundOn();
-        processAccessPoints(inboundOn, outboundOn, processed);
+        AccessPointID inbound = convertIntersectionAccessPointID(pkg.getInboundOn());
+        processed.setInboundOnLaneID(inbound.laneID());
+        processed.setInboundOnApproachID(inbound.approachID());
+        processed.setInboundOnLaneConnectionID(inbound.connectionID());
+
+        AccessPointID outbound = convertIntersectionAccessPointID(pkg.getOutboundOn());
+        processed.setOutboundOnLaneID(outbound.laneID());
+        processed.setOutboundOnApproachID(outbound.approachID());
+        processed.setOutboundOnLaneConnectionID(outbound.connectionID());
 
         PrioritizationResponseStatus status = pkg.getStatus();
-        if (status != null && status.getName() != null) {
+        if (status != null) {
             ProcessedPrioritizationResponseStatus processedStatus
                     = ProcessedPrioritizationResponseStatus.fromName(status.getName());
             processed.setStatus(processedStatus);
@@ -107,33 +113,15 @@ public class SsmConverter {
         processRequestorType(requestorType, processed);
     }
 
-    private void processAccessPoints(final IntersectionAccessPoint inboundOn, final IntersectionAccessPoint outboundOn,
-                                     ProcessedSsm processed) {
-        var inbound = convertIntersectionAccessPointID(inboundOn);
-        processed.setInboundOnLaneID(inbound.laneID());
-        processed.setInboundOnApproachID(inbound.approachID());
-        processed.setInboundOnLaneConnectionID(inbound.connectionID());
-
-        var outbound = convertIntersectionAccessPointID(outboundOn);
-        processed.setOutboundOnLaneID(outbound.laneID());
-        processed.setOutboundOnApproachID(outbound.approachID());
-        processed.setOutboundOnLaneConnectionID(outbound.connectionID());
-    }
-
-
 
     private void processETA(final SignalStatusPackage pkg, final ProcessedSsm processed, final int year) {
-        MinuteOfTheYear moy = pkg.getMinute();
-        DSecond dsec = pkg.getSecond();
-        ZonedDateTime ts = convertMinuteOfYearAndDSecond(moy, year, dsec);
+        ZonedDateTime ts = convertMinuteOfYearAndDSecond(pkg.getMinute(), year, pkg.getSecond());
         processed.setEstimatedTimeOfArrival(ts);
         if (pkg.getDuration() != null) {
             Duration duration = Duration.ofMillis(pkg.getDuration().getValue());
             processed.setEstimatedTimeOfArrivalDuration(duration);
         }
     }
-
-
 
     private void processRequestorType(final RequestorType requestorType, final ProcessedSsm processed) {
         // Use this role if top-level role is missing
@@ -146,8 +134,7 @@ public class SsmConverter {
         if (iso != null) {
             processed.setRequesterIso3833VehicleType((int)iso.getValue());
         }
-        RequestImportanceLevel request = requestorType.getRequest();
-        processed.setRequestImportanceLevel(convertRequestImportanceLevel(request));
+        processed.setRequestImportanceLevel(convertRequestImportanceLevel(requestorType.getRequest()));
     }
 
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
@@ -2,42 +2,91 @@ package us.dot.its.jpo.geojsonconverter.converter.ssm;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import us.dot.its.jpo.asn.j2735.r2024.Common.DSecond;
-import us.dot.its.jpo.asn.j2735.r2024.Common.MinuteOfTheYear;
-import us.dot.its.jpo.asn.j2735.r2024.Common.MsgCount;
-import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusList;
-import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessage;
-import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame;
+import us.dot.its.jpo.asn.j2735.r2024.Common.*;
+import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.*;
+import us.dot.its.jpo.geojsonconverter.converter.FieldConversions;
 import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
 
 @Component
 @Slf4j
 public class SsmConverter {
 
-    public ProcessedSsm processSsm(final SignalStatusMessageMessageFrame ssmFrame) {
-        var processed = new ProcessedSsm();
+    public List<ProcessedSsm> processedSsm(final SignalStatusMessageMessageFrame ssmFrame) {
+        // We don't know what year it is, assume the time is now
+        var now = ZonedDateTime.now();
+        return processSsm(ssmFrame, now.getYear());
+    }
+
+    public List<ProcessedSsm> processSsm(final SignalStatusMessageMessageFrame ssmFrame, final int year) {
+        var list = new ArrayList<ProcessedSsm>();
+
 
         if (ssmFrame == null) {
             log.error("SSM Message Frame is null");
-            return processed;
+            return list;
         }
 
         SignalStatusMessage ssm = ssmFrame.getValue();
 
         if (ssm == null) {
             log.error("SignalStatusMessage is null");
-            return processed;
+            return list;
         }
 
-        MsgCount sequenceNumber = ssm.getSequenceNumber();
-        if (sequenceNumber != null) {
-            processed.setSequenceNumber((int)sequenceNumber.getValue());
-        }
+        final Integer sequenceNumber = convertMsgCount(ssm.getSequenceNumber());
 
         MinuteOfTheYear moy = ssm.getTimeStamp();
         DSecond dsec = ssm.getSecond();
+        final ZonedDateTime timeStamp = convertMinuteOfYearAndDSecond(moy, year, dsec);
 
         SignalStatusList sslist = ssm.getStatus();
+        if (sslist == null) return list;
+        for (var status : sslist) {
+            final Integer statusSequenceNumber = convertMsgCount(status.getSequenceNumber());
+            final RegionIntersectionId regInt = convertIntersectionReferenceID(status.getId());
+            SignalStatusPackageList packageList = status.getSigStatus();
+            if (packageList == null) continue;
+            for (SignalStatusPackage pkg : packageList) {
+                var processed = new ProcessedSsm();
+                processed.setSequenceNumber(sequenceNumber);
+                processed.setTimeStamp(timeStamp);
+                processed.setStatusSequenceNumber(statusSequenceNumber);
+                processed.setRegion(regInt.region());
+                processed.setIntersectionId(regInt.intersectionId());
+                processSignalStatusPackage(pkg, processed);
+                list.add(processed);
+            }
+        }
+    }
+
+    private void processSignalStatusPackage(final SignalStatusPackage pkg, final ProcessedSsm processed, final int year) {
+
+        SignalRequesterInfo requester = pkg.getRequester();
+        IntersectionAccessPoint inboundOn = pkg.getInboundOn();
+        IntersectionAccessPoint outboundOn = pkg.getOutboundOn();
+
+        // ETA
+        MinuteOfTheYear moy = pkg.getMinute();
+        DSecond dsec = pkg.getSecond();
+        ZonedDateTime ts = convertMinuteOfYearAndDSecond(moy, year, dsec);
+        processed.setEstimatedTimeOfArrival(ts);
+        if (pkg.getDuration() != null) {
+            Duration duration = Duration.ofMillis(pkg.getDuration().getValue());
+            processed.setEstimatedTimeOfArrivalDuration(duration);
+        }
+
+        PrioritizationResponseStatus status = pkg.getStatus();
+
+
+
 
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverter.java
@@ -69,7 +69,7 @@ public class SsmConverter {
 
 
     private void processSignalStatusPackage(final SignalStatusPackage pkg, final ProcessedSsm processed, final int year) {
-
+        if (pkg == null) { return; }
         SignalRequesterInfo requester = pkg.getRequester();
         processRequester(requester, processed);
 
@@ -96,6 +96,7 @@ public class SsmConverter {
     }
 
     private void processRequester(final SignalRequesterInfo requester, final ProcessedSsm processed) {
+        if (requester == null) { return; }
         VehicleID vehicleId = requester.getId();
         processed.setVehicleID(convertVehicleID(vehicleId));
 
@@ -115,6 +116,7 @@ public class SsmConverter {
 
 
     private void processETA(final SignalStatusPackage pkg, final ProcessedSsm processed, final int year) {
+        if (pkg == null) { return; }
         ZonedDateTime ts = convertMinuteOfYearAndDSecond(pkg.getMinute(), year, pkg.getSecond());
         processed.setEstimatedTimeOfArrival(ts);
         if (pkg.getDuration() != null) {
@@ -125,6 +127,7 @@ public class SsmConverter {
 
     private void processRequestorType(final RequestorType requestorType, final ProcessedSsm processed) {
         // Use this role if top-level role is missing
+        if (requestorType == null) { return; }
         if (processed.getRequesterRole() == null) {
             processed.setRequesterRole(convertBasicVehicleRole(requestorType.getRole()));
         }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopology.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopology.java
@@ -3,11 +3,9 @@ package us.dot.its.jpo.geojsonconverter.converter.ssm;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.Produced;
 import us.dot.its.jpo.geojsonconverter.partitioner.IntersectionIdPartitioner;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
@@ -26,7 +24,8 @@ public class SsmTopology {
     public static Topology build(
             String ssmOdeJsonTopic,
             String ssmProcessedJsonTopic,
-            SsmJsonValidator ssmJsonValidator) {
+            SsmJsonValidator ssmJsonValidator,
+            SsmConverter converter) {
         var builder = new StreamsBuilder();
         var rawOdeSsmStream = builder.stream(ssmOdeJsonTopic, Consumed.with(Serdes.Void(), Serdes.Bytes()));
         var validatedOdeSsmStream = rawOdeSsmStream.mapValues((Void key, Bytes value) -> {
@@ -49,7 +48,7 @@ public class SsmTopology {
         });
 
         var processedSsmStream =
-                validatedOdeSsmStream.flatMap(new SsmTransformer());
+                validatedOdeSsmStream.flatMap(new SsmTransformer(converter));
 
         processedSsmStream.to(ssmProcessedJsonTopic,
                 Produced.with(

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopology.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopology.java
@@ -27,31 +27,31 @@ public class SsmTopology {
             SsmJsonValidator ssmJsonValidator,
             SsmConverter converter) {
         var builder = new StreamsBuilder();
-        var rawOdeSsmStream = builder.stream(ssmOdeJsonTopic, Consumed.with(Serdes.Void(), Serdes.Bytes()));
-        var validatedOdeSsmStream = rawOdeSsmStream.mapValues((Void key, Bytes value) -> {
-            var rawMessageFrame = new DeserializedRawMessageFrame();
-            try (var serdes = OdeMessageFrame()) {
-                JsonValidatorResult validationResults = ssmJsonValidator.validate(value.get());
-                rawMessageFrame.setOdeMessageFrameData(
-                        serdes.deserializer().deserialize(ssmOdeJsonTopic, value.get()));
-                rawMessageFrame.setValidationResults(validationResults);
-                log.debug(validationResults.describeResults());
-            } catch (Exception e) {
-                JsonValidatorResult validatorResult = new JsonValidatorResult();
-                validatorResult.addException(e);
-                rawMessageFrame.setValidationResults(validatorResult);
-                rawMessageFrame.setValidationFailure(true);
-                rawMessageFrame.setFailedMessage(e.getMessage());
-                log.error("Error in SSM validation: ", e);
-            }
-            return rawMessageFrame;
-        });
 
-        var processedSsmStream =
-                validatedOdeSsmStream.flatMap(new SsmTransformer(converter));
-
-        processedSsmStream.to(ssmProcessedJsonTopic,
-                Produced.with(
+        builder
+                .stream(ssmOdeJsonTopic,
+                        Consumed.with(Serdes.Void(), Serdes.Bytes()))
+                .mapValues((Void key, Bytes value) -> {
+                    var rawMessageFrame = new DeserializedRawMessageFrame();
+                    try (var serdes = OdeMessageFrame()) {
+                        JsonValidatorResult validationResults = ssmJsonValidator.validate(value.get());
+                        rawMessageFrame.setOdeMessageFrameData(
+                                serdes.deserializer().deserialize(ssmOdeJsonTopic, value.get()));
+                        rawMessageFrame.setValidationResults(validationResults);
+                        log.debug(validationResults.describeResults());
+                    } catch (Exception e) {
+                        JsonValidatorResult validatorResult = new JsonValidatorResult();
+                        validatorResult.addException(e);
+                        rawMessageFrame.setValidationResults(validatorResult);
+                        rawMessageFrame.setValidationFailure(true);
+                        rawMessageFrame.setFailedMessage(e.getMessage());
+                        log.error("Error in SSM validation: ", e);
+                    }
+                    return rawMessageFrame;
+                })
+                .flatMap(new SsmTransformer(converter))
+                .to(ssmProcessedJsonTopic,
+                    Produced.with(
                         RsuIntersectionKey(),
                         JsonSerdes.ProcessedSsm(),
                         new IntersectionIdPartitioner<RsuIntersectionKey, ProcessedSsm>()));

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopology.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopology.java
@@ -49,7 +49,7 @@ public class SsmTopology {
                     }
                     return rawMessageFrame;
                 })
-                .flatMap(new SsmTransformer(converter))
+                .map(new SsmTransformer(converter))
                 .to(ssmProcessedJsonTopic,
                     Produced.with(
                         RsuIntersectionKey(),

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopology.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopology.java
@@ -1,0 +1,62 @@
+package us.dot.its.jpo.geojsonconverter.converter.ssm;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.Produced;
+import us.dot.its.jpo.geojsonconverter.partitioner.IntersectionIdPartitioner;
+import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
+import us.dot.its.jpo.geojsonconverter.pojos.common.DeserializedRawMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+import us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes;
+import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
+import us.dot.its.jpo.geojsonconverter.validator.SsmJsonValidator;
+
+import static us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes.OdeMessageFrame;
+import static us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes.RsuIntersectionKey;
+
+@Slf4j
+public class SsmTopology {
+
+    public static Topology build(
+            String ssmOdeJsonTopic,
+            String ssmProcessedJsonTopic,
+            SsmJsonValidator ssmJsonValidator) {
+        var builder = new StreamsBuilder();
+        var rawOdeSsmStream = builder.stream(ssmOdeJsonTopic, Consumed.with(Serdes.Void(), Serdes.Bytes()));
+        var validatedOdeSsmStream = rawOdeSsmStream.mapValues((Void key, Bytes value) -> {
+            var rawMessageFrame = new DeserializedRawMessageFrame();
+            try (var serdes = OdeMessageFrame()) {
+                JsonValidatorResult validationResults = ssmJsonValidator.validate(value.get());
+                rawMessageFrame.setOdeMessageFrameData(
+                        serdes.deserializer().deserialize(ssmOdeJsonTopic, value.get()));
+                rawMessageFrame.setValidationResults(validationResults);
+                log.debug(validationResults.describeResults());
+            } catch (Exception e) {
+                JsonValidatorResult validatorResult = new JsonValidatorResult();
+                validatorResult.addException(e);
+                rawMessageFrame.setValidationResults(validatorResult);
+                rawMessageFrame.setValidationFailure(true);
+                rawMessageFrame.setFailedMessage(e.getMessage());
+                log.error("Error in SSM validation: ", e);
+            }
+            return rawMessageFrame;
+        });
+
+        var processedSsmStream =
+                validatedOdeSsmStream.flatMap(new SsmTransformer());
+
+        processedSsmStream.to(ssmProcessedJsonTopic,
+                Produced.with(
+                        RsuIntersectionKey(),
+                        JsonSerdes.ProcessedSsm(),
+                        new IntersectionIdPartitioner<RsuIntersectionKey, ProcessedSsm>()));
+
+        return builder.build();
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
@@ -1,33 +1,83 @@
 package us.dot.its.jpo.geojsonconverter.converter.ssm;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
+import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessage;
+import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
 import us.dot.its.jpo.geojsonconverter.pojos.common.DeserializedRawMessageFrame;
 import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+import us.dot.its.jpo.geojsonconverter.utils.ProcessedSchemaVersions;
+import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
+import us.dot.its.jpo.ode.model.OdeMessageFrameData;
+import us.dot.its.jpo.ode.model.OdeMessageFrameMetadata;
+import us.dot.its.jpo.ode.model.OdeMessageFramePayload;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * KeyValueMapper transforms one SSM to one or more ProcessedSsms, for use in flatMap in the Topology.
  * Implement this as a KeyValueMapper, because the Transformer interface is deprecated.
  * The transformation is not stateful, so this doesn't need to be a processor.
  */
+@Slf4j
 public class SsmTransformer implements KeyValueMapper<Void, DeserializedRawMessageFrame, Iterable<KeyValue<RsuIntersectionKey, ProcessedSsm>>> {
 
     private final SsmConverter converter;
-    private final int year;
 
-    public SsmTransformer(SsmConverter converter, int year) {
+    public SsmTransformer(SsmConverter converter) {
         this.converter = converter;
-        this.year = year;
     }
 
     @Override
-    public Iterable<KeyValue<RsuIntersectionKey, ProcessedSsm>> apply(Void key, DeserializedRawMessageFrame value) {
+    public Iterable<KeyValue<RsuIntersectionKey, ProcessedSsm>> apply(Void rawKey, DeserializedRawMessageFrame rawSsm) {
 
         try {
-
+            if (!rawSsm.isValidationFailure()) {
+                OdeMessageFrameData rawValue = rawSsm.getOdeMessageFrameData();
+                OdeMessageFrameMetadata metadata = rawValue.getMetadata();
+                OdeMessageFramePayload payload = rawValue.getPayload();
+                SignalStatusMessageMessageFrame ssmMessageFrame = (SignalStatusMessageMessageFrame)payload.getData();
+                JsonValidatorResult validationResults = rawSsm.getValidationResults();
+                return createProcessedSsmList(ssmMessageFrame, metadata, validationResults);
+            }
         } catch (Exception e) {
-
+            log.error("Error converting Ssm to Processed Ssm", e);
         }
+        return new ArrayList<>();
+    }
+
+    private List<KeyValue<RsuIntersectionKey, ProcessedSsm>> createProcessedSsmList(SignalStatusMessageMessageFrame ssm,
+                 OdeMessageFrameMetadata metadata, JsonValidatorResult validationResults) {
+
+        final ZonedDateTime odeReceivedAt = Instant.parse(metadata.getOdeReceivedAt()).atZone(ZoneId.of("UTC"));
+        final int year = odeReceivedAt.getYear();
+
+        // Process message frame
+        var processedSsmList =  converter.processSsm(ssm, year);
+
+        List<KeyValue<RsuIntersectionKey, ProcessedSsm>> keyValueList = new ArrayList<>();
+
+        // Add metadata
+        for (ProcessedSsm processedSsm : processedSsmList) {
+            processedSsm.setOdeReceivedAt(odeReceivedAt);
+            processedSsm.setAsn1(metadata.getAsn1());
+            processedSsm.setOriginIp(metadata.getOriginIp());
+            processedSsm.setSchemaVersion(ProcessedSchemaVersions.PROCESSED_SSM_SCHEMA_VERSION);
+
+            var key = new RsuIntersectionKey();
+            key.setRsuId(metadata.getOriginIp());
+            key.setIntersectionId(processedSsm.getIntersectionId());
+            key.setRegion(processedSsm.getRegion());
+
+            keyValueList.add(new KeyValue<>(key, processedSsm));
+        }
+
+        return keyValueList;
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
@@ -3,22 +3,19 @@ package us.dot.its.jpo.geojsonconverter.converter.ssm;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessage;
 import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
 import us.dot.its.jpo.geojsonconverter.pojos.common.DeserializedRawMessageFrame;
 import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
 import us.dot.its.jpo.geojsonconverter.utils.ProcessedSchemaVersions;
-import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
 import us.dot.its.jpo.ode.model.OdeMessageFrameData;
 import us.dot.its.jpo.ode.model.OdeMessageFrameMetadata;
 import us.dot.its.jpo.ode.model.OdeMessageFramePayload;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * KeyValueMapper transforms one SSM to one or more ProcessedSsms, for use in flatMap in the Topology.
@@ -27,7 +24,7 @@ import java.util.List;
  */
 @Slf4j
 public class SsmTransformer
-        implements KeyValueMapper<Void, DeserializedRawMessageFrame, Iterable<KeyValue<RsuIntersectionKey, ProcessedSsm>>> {
+        implements KeyValueMapper<Void, DeserializedRawMessageFrame, KeyValue<RsuIntersectionKey, ProcessedSsm>> {
 
     private final SsmConverter converter;
 
@@ -36,7 +33,7 @@ public class SsmTransformer
     }
 
     @Override
-    public Iterable<KeyValue<RsuIntersectionKey, ProcessedSsm>> apply(Void rawKey, DeserializedRawMessageFrame rawSsm) {
+    public KeyValue<RsuIntersectionKey, ProcessedSsm> apply(Void rawKey, DeserializedRawMessageFrame rawSsm) {
 
         try {
             if (!rawSsm.isValidationFailure()) {
@@ -44,41 +41,47 @@ public class SsmTransformer
                 OdeMessageFrameMetadata metadata = rawValue.getMetadata();
                 OdeMessageFramePayload payload = rawValue.getPayload();
                 SignalStatusMessageMessageFrame ssmMessageFrame = (SignalStatusMessageMessageFrame)payload.getData();
-                JsonValidatorResult validationResults = rawSsm.getValidationResults();
-                return createProcessedSsmList(ssmMessageFrame, metadata, validationResults);
+                KeyValue<RsuIntersectionKey, ProcessedSsm> processedSsm
+                        = createProcessedSsm(ssmMessageFrame, metadata);
+                converter.jsonValidation(processedSsm.value, rawSsm.getValidationResults());
+                return processedSsm;
+            } else {
+                var processed = new ProcessedSsm();
+                ZonedDateTime utcDateTime = ZonedDateTime.now(ZoneOffset.UTC);
+                processed.setOdeReceivedAt(utcDateTime);
+                converter.jsonValidation(processed, rawSsm.getValidationResults());
+                RsuIntersectionKey key = new RsuIntersectionKey();
+                key.setRsuId("ERROR");
+                return KeyValue.pair(key, processed);
             }
         } catch (Exception e) {
             log.error("Error converting Ssm to Processed Ssm", e);
         }
-        return new ArrayList<>();
+        var key = new RsuIntersectionKey();
+        key.setRsuId("ERROR");
+        return KeyValue.pair(key, null);
     }
 
-    private List<KeyValue<RsuIntersectionKey, ProcessedSsm>> createProcessedSsmList(SignalStatusMessageMessageFrame ssm,
-                 OdeMessageFrameMetadata metadata, JsonValidatorResult validationResults) {
+    private KeyValue<RsuIntersectionKey, ProcessedSsm> createProcessedSsm(SignalStatusMessageMessageFrame ssm,
+                 OdeMessageFrameMetadata metadata) {
 
         final ZonedDateTime odeReceivedAt = Instant.parse(metadata.getOdeReceivedAt()).atZone(ZoneId.of("UTC"));
         final int year = odeReceivedAt.getYear();
 
         // Process message frame
-        var processedSsmList =  converter.processSsm(ssm, year);
-
-        List<KeyValue<RsuIntersectionKey, ProcessedSsm>> keyValueList = new ArrayList<>();
+        ProcessedSsm processedSsm =  converter.processSsm(ssm, year);
 
         // Add metadata
-        for (ProcessedSsm processedSsm : processedSsmList) {
-            processedSsm.setOdeReceivedAt(odeReceivedAt);
-            processedSsm.setAsn1(metadata.getAsn1());
-            processedSsm.setOriginIp(metadata.getOriginIp());
-            processedSsm.setSchemaVersion(ProcessedSchemaVersions.PROCESSED_SSM_SCHEMA_VERSION);
+        processedSsm.setOdeReceivedAt(odeReceivedAt);
+        processedSsm.setAsn1(metadata.getAsn1());
+        processedSsm.setOriginIp(metadata.getOriginIp());
+        processedSsm.setSchemaVersion(ProcessedSchemaVersions.PROCESSED_SSM_SCHEMA_VERSION);
 
-            var key = new RsuIntersectionKey();
-            key.setRsuId(metadata.getOriginIp());
-            key.setIntersectionId(processedSsm.getIntersectionId());
-            key.setRegion(processedSsm.getRegion());
+        var key = new RsuIntersectionKey();
+        key.setRsuId(metadata.getOriginIp());
+        key.setIntersectionId(processedSsm.getIntersectionId());
+        key.setRegion(processedSsm.getRegion());
 
-            keyValueList.add(new KeyValue<>(key, processedSsm));
-        }
-
-        return keyValueList;
+        return new KeyValue<>(key, processedSsm);
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
@@ -26,7 +26,8 @@ import java.util.List;
  * The transformation is not stateful, so this doesn't need to be a processor.
  */
 @Slf4j
-public class SsmTransformer implements KeyValueMapper<Void, DeserializedRawMessageFrame, Iterable<KeyValue<RsuIntersectionKey, ProcessedSsm>>> {
+public class SsmTransformer
+        implements KeyValueMapper<Void, DeserializedRawMessageFrame, Iterable<KeyValue<RsuIntersectionKey, ProcessedSsm>>> {
 
     private final SsmConverter converter;
 

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
@@ -1,0 +1,33 @@
+package us.dot.its.jpo.geojsonconverter.converter.ssm;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
+import us.dot.its.jpo.geojsonconverter.pojos.common.DeserializedRawMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+
+/**
+ * KeyValueMapper transforms one SSM to one or more ProcessedSsms, for use in flatMap in the Topology.
+ * Implement this as a KeyValueMapper, because the Transformer interface is deprecated.
+ * The transformation is not stateful, so this doesn't need to be a processor.
+ */
+public class SsmTransformer implements KeyValueMapper<Void, DeserializedRawMessageFrame, Iterable<KeyValue<RsuIntersectionKey, ProcessedSsm>>> {
+
+    private final SsmConverter converter;
+    private final int year;
+
+    public SsmTransformer(SsmConverter converter, int year) {
+        this.converter = converter;
+        this.year = year;
+    }
+
+    @Override
+    public Iterable<KeyValue<RsuIntersectionKey, ProcessedSsm>> apply(Void key, DeserializedRawMessageFrame value) {
+
+        try {
+
+        } catch (Exception e) {
+
+        }
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
@@ -67,10 +67,9 @@ public class SsmTransformer
                  OdeMessageFrameMetadata metadata) {
 
         final ZonedDateTime odeReceivedAt = Instant.parse(metadata.getOdeReceivedAt()).atZone(ZoneId.of("UTC"));
-        final int year = odeReceivedAt.getYear();
 
         // Process message frame
-        ProcessedSsm processedSsm =  converter.processSsm(ssm, year);
+        ProcessedSsm processedSsm =  converter.processSsm(ssm, odeReceivedAt);
 
         // Add metadata
         processedSsm.setOdeReceivedAt(odeReceivedAt);

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
@@ -40,7 +40,6 @@ public class SsmTransformer
                 OdeMessageFrameData rawValue = rawSsm.getOdeMessageFrameData();
                 OdeMessageFrameMetadata metadata = rawValue.getMetadata();
                 OdeMessageFramePayload payload = rawValue.getPayload();
-                log.info("payload: {}", payload.getData());
                 SignalStatusMessageMessageFrame ssmMessageFrame = (SignalStatusMessageMessageFrame)payload.getData();
                 KeyValue<RsuIntersectionKey, ProcessedSsm> processedSsm
                         = createProcessedSsm(ssmMessageFrame, metadata);

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTransformer.java
@@ -40,6 +40,7 @@ public class SsmTransformer
                 OdeMessageFrameData rawValue = rawSsm.getOdeMessageFrameData();
                 OdeMessageFrameMetadata metadata = rawValue.getMetadata();
                 OdeMessageFramePayload payload = rawValue.getPayload();
+                log.info("payload: {}", payload.getData());
                 SignalStatusMessageMessageFrame ssmMessageFrame = (SignalStatusMessageMessageFrame)payload.getData();
                 KeyValue<RsuIntersectionKey, ProcessedSsm> processedSsm
                         = createProcessedSsm(ssmMessageFrame, metadata);
@@ -79,8 +80,14 @@ public class SsmTransformer
 
         var key = new RsuIntersectionKey();
         key.setRsuId(metadata.getOriginIp());
-        key.setIntersectionId(processedSsm.getIntersectionId());
-        key.setRegion(processedSsm.getRegion());
+        Integer intersectionId = processedSsm.getIntersectionId();
+        if (intersectionId != null) {
+            key.setIntersectionId(intersectionId);
+        }
+        Integer region = processedSsm.getRegion();
+        if (region != null) {
+            key.setRegion(region);
+        }
 
         return new KeyValue<>(key, processedSsm);
     }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKey.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKey.java
@@ -3,6 +3,7 @@ package us.dot.its.jpo.geojsonconverter.partitioner;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import us.dot.its.jpo.asn.j2735.r2024.Common.IntersectionID;
 import us.dot.its.jpo.asn.j2735.r2024.Common.IntersectionReferenceID;
 import us.dot.its.jpo.asn.j2735.r2024.Common.RoadRegulatorID;
@@ -13,7 +14,7 @@ import us.dot.its.jpo.asn.j2735.r2024.Common.RoadRegulatorID;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class RsuIntersectionKey implements RsuIdKey, IntersectionKey {
+public class RsuIntersectionKey implements RsuIdKey, IntersectionKey, Comparable<RsuIntersectionKey> {
 
     private String rsuId;
     private int intersectionId;
@@ -67,5 +68,20 @@ public class RsuIntersectionKey implements RsuIdKey, IntersectionKey {
     public String toString() {
         return "{" + " rsuId='" + getRsuId() + "'" + ", intersectionId='" + getIntersectionId() + "'" + ", region='"
                 + getRegion() + "'" + "}";
+    }
+
+    // Implement comparable interface to allow easily sorting the in a predictable order
+    // e.g. in SortedSet.
+    @Override
+    public int compareTo(RsuIntersectionKey o) {
+        int compareRsuId = StringUtils.compare(getRsuId(), o.getRsuId());
+        if (compareRsuId != 0) {
+            return compareRsuId;
+        }
+        int compareRegion = Integer.compare(getRegion(), o.getRegion());
+        if (compareRegion != 0) {
+            return compareRegion;
+        }
+        return Integer.compare(getIntersectionId(), o.getIntersectionId());
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuVehicleIdKey.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuVehicleIdKey.java
@@ -1,0 +1,19 @@
+package us.dot.its.jpo.geojsonconverter.partitioner;
+
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class RsuVehicleIdKey implements RsuIdKey {
+
+    private String rsuId;
+    private String vehicleId;
+
+    @Override
+    public String getRsuId() {
+        return rsuId;
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/DeserializedRawMessageFrame.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/DeserializedRawMessageFrame.java
@@ -1,0 +1,25 @@
+package us.dot.its.jpo.geojsonconverter.pojos.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Generated;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import us.dot.its.jpo.geojsonconverter.validator.JsonValidatorResult;
+import us.dot.its.jpo.ode.model.OdeMessageFrameData;
+
+@Data
+@Generated
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Slf4j
+public class DeserializedRawMessageFrame {
+    OdeMessageFrameData odeMessageFrameData;
+    JsonValidatorResult validationResults;
+    boolean validationFailure;
+    String failedMessage;
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/ProcessedBasicVehicleRole.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/ProcessedBasicVehicleRole.java
@@ -1,0 +1,53 @@
+package us.dot.its.jpo.geojsonconverter.pojos.common;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
+
+@Getter
+public enum ProcessedBasicVehicleRole {
+    BASICVEHICLE(0, "basicVehicle"),
+    PUBLICTRANSPORT(1, "publicTransport"),
+    SPECIALTRANSPORT(2, "specialTransport"),
+    DANGEROUSGOODS(3, "dangerousGoods"),
+    ROADWORK(4, "roadWork"),
+    ROADRESCUE(5, "roadRescue"),
+    EMERGENCY(6, "emergency"),
+    SAFETYCAR(7, "safetyCar"),
+    NONE_UNKNOWN(8, "none-unknown"),
+    TRUCK(9, "truck"),
+    MOTORCYCLE(10, "motorcycle"),
+    ROADSIDESOURCE(11, "roadSideSource"),
+    POLICE(12, "police"),
+    FIRE(13, "fire"),
+    AMBULANCE(14, "ambulance"),
+    DOT(15, "dot"),
+    TRANSIT(16, "transit"),
+    SLOWMOVING(17, "slowMoving"),
+    STOPNGO(18, "stopNgo"),
+    CYCLIST(19, "cyclist"),
+    PEDESTRIAN(20, "pedestrian"),
+    NONMOTORIZED(21, "nonMotorized"),
+    MILITARY(22, "military");
+
+    private final int index;
+    private final String name;
+
+    private ProcessedBasicVehicleRole(int index, String name) {
+        this.index = index;
+        this.name = name;
+    }
+
+    public static ProcessedBasicVehicleRole fromName(String name) {
+        if (StringUtils.isBlank(name)) {
+            return null;
+        }
+        for (ProcessedBasicVehicleRole enumValue : ProcessedBasicVehicleRole.values()) {
+            if (Objects.equals(enumValue.getName(), name)) {
+                return enumValue;
+            }
+        }
+        throw new IllegalArgumentException(name);
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/ProcessedPrioritizationResponseStatus.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/ProcessedPrioritizationResponseStatus.java
@@ -1,0 +1,38 @@
+package us.dot.its.jpo.geojsonconverter.pojos.common;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
+
+@Getter
+public enum ProcessedPrioritizationResponseStatus {
+    UNKNOWN(0, "unknown"),
+    REQUESTED(1, "requested"),
+    PROCESSING(2, "processing"),
+    WATCHOTHERTRAFFIC(3, "watchOtherTraffic"),
+    GRANTED(4, "granted"),
+    REJECTED(5, "rejected"),
+    MAXPRESENCE(6, "maxPresence"),
+    RESERVICELOCKED(7, "reserviceLocked");
+
+    private final int index;
+    private final String name;
+
+    private ProcessedPrioritizationResponseStatus(int index, String name) {
+        this.index = index;
+        this.name = name;
+    }
+
+    public static ProcessedPrioritizationResponseStatus fromName(String name) {
+        if (StringUtils.isBlank(name)) {
+            return null;
+        }
+        for (ProcessedPrioritizationResponseStatus enumValue : ProcessedPrioritizationResponseStatus.values()) {
+            if (Objects.equals(enumValue.getName(), name)) {
+                return enumValue;
+            }
+        }
+        throw new IllegalArgumentException(name);
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/ProcessedRequestImportanceLevel.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/ProcessedRequestImportanceLevel.java
@@ -1,0 +1,46 @@
+package us.dot.its.jpo.geojsonconverter.pojos.common;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
+
+@Getter
+public enum ProcessedRequestImportanceLevel {
+    REQUESTIMPORTANCELEVELUNKNOWN(0, "requestImportanceLevelUnKnown"),
+    REQUESTIMPORTANCELEVEL1(1, "requestImportanceLevel1"),
+    REQUESTIMPORTANCELEVEL2(2, "requestImportanceLevel2"),
+    REQUESTIMPORTANCELEVEL3(3, "requestImportanceLevel3"),
+    REQUESTIMPORTANCELEVEL4(4, "requestImportanceLevel4"),
+    REQUESTIMPORTANCELEVEL5(5, "requestImportanceLevel5"),
+    REQUESTIMPORTANCELEVEL6(6, "requestImportanceLevel6"),
+    REQUESTIMPORTANCELEVEL7(7, "requestImportanceLevel7"),
+    REQUESTIMPORTANCELEVEL8(8, "requestImportanceLevel8"),
+    REQUESTIMPORTANCELEVEL9(9, "requestImportanceLevel9"),
+    REQUESTIMPORTANCELEVEL10(10, "requestImportanceLevel10"),
+    REQUESTIMPORTANCELEVEL11(11, "requestImportanceLevel11"),
+    REQUESTIMPORTANCELEVEL12(12, "requestImportanceLevel12"),
+    REQUESTIMPORTANCELEVEL13(13, "requestImportanceLevel13"),
+    REQUESTIMPORTANCELEVEL14(14, "requestImportanceLevel14"),
+    REQUESTIMPORTANCERESERVED(15, "requestImportanceReserved");
+
+    private final int index;
+    private final String name;
+
+    private ProcessedRequestImportanceLevel(int index, String name) {
+        this.index = index;
+        this.name = name;
+    }
+
+    public static ProcessedRequestImportanceLevel fromName(String name) {
+        if (StringUtils.isBlank(name)) {
+            return null;
+        }
+        for (ProcessedRequestImportanceLevel enumValue : ProcessedRequestImportanceLevel.values()) {
+            if (Objects.equals(enumValue.getName(), name)) {
+                return enumValue;
+            }
+        }
+        throw new IllegalArgumentException(name);
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/ProcessedRequestSubRole.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/ProcessedRequestSubRole.java
@@ -1,0 +1,46 @@
+package us.dot.its.jpo.geojsonconverter.pojos.common;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
+
+@Getter
+public enum ProcessedRequestSubRole {
+    REQUESTSUBROLEUNKNOWN(0, "requestSubRoleUnKnown"),
+    REQUESTSUBROLE1(1, "requestSubRole1"),
+    REQUESTSUBROLE2(2, "requestSubRole2"),
+    REQUESTSUBROLE3(3, "requestSubRole3"),
+    REQUESTSUBROLE4(4, "requestSubRole4"),
+    REQUESTSUBROLE5(5, "requestSubRole5"),
+    REQUESTSUBROLE6(6, "requestSubRole6"),
+    REQUESTSUBROLE7(7, "requestSubRole7"),
+    REQUESTSUBROLE8(8, "requestSubRole8"),
+    REQUESTSUBROLE9(9, "requestSubRole9"),
+    REQUESTSUBROLE10(10, "requestSubRole10"),
+    REQUESTSUBROLE11(11, "requestSubRole11"),
+    REQUESTSUBROLE12(12, "requestSubRole12"),
+    REQUESTSUBROLE13(13, "requestSubRole13"),
+    REQUESTSUBROLE14(14, "requestSubRole14"),
+    REQUESTSUBROLERESERVED(15, "requestSubRoleReserved");
+
+    private final int index;
+    private final String name;
+
+    private ProcessedRequestSubRole(int index, String name) {
+        this.index = index;
+        this.name = name;
+    }
+
+    public static ProcessedRequestSubRole fromName(String name) {
+        if (StringUtils.isBlank(name)) {
+            return null;
+        }
+        for (ProcessedRequestSubRole enumValue : ProcessedRequestSubRole.values()) {
+            if (Objects.equals(enumValue.getName(), name)) {
+                return enumValue;
+            }
+        }
+        throw new IllegalArgumentException(name);
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/ProcessedVehicleType.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/common/ProcessedVehicleType.java
@@ -1,0 +1,46 @@
+package us.dot.its.jpo.geojsonconverter.pojos.common;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
+
+@Getter
+public enum ProcessedVehicleType {
+    NONE(0, "none"),
+    UNKNOWN(1, "unknown"),
+    SPECIAL(2, "special"),
+    MOTO(3, "moto"),
+    CAR(4, "car"),
+    CAROTHER(5, "carOther"),
+    BUS(6, "bus"),
+    AXLECNT2(7, "axleCnt2"),
+    AXLECNT3(8, "axleCnt3"),
+    AXLECNT4(9, "axleCnt4"),
+    AXLECNT4TRAILER(10, "axleCnt4Trailer"),
+    AXLECNT5TRAILER(11, "axleCnt5Trailer"),
+    AXLECNT6TRAILER(12, "axleCnt6Trailer"),
+    AXLECNT5MULTITRAILER(13, "axleCnt5MultiTrailer"),
+    AXLECNT6MULTITRAILER(14, "axleCnt6MultiTrailer"),
+    AXLECNT7MULTITRAILER(15, "axleCnt7MultiTrailer");
+
+    private final int index;
+    private final String name;
+
+    private ProcessedVehicleType(int index, String name) {
+        this.index = index;
+        this.name = name;
+    }
+
+    public static ProcessedVehicleType fromName(String name) {
+        if (StringUtils.isBlank(name)) {
+            return null;
+        }
+        for (ProcessedVehicleType enumValue : ProcessedVehicleType.values()) {
+            if (Objects.equals(enumValue.getName(), name)) {
+                return enumValue;
+            }
+        }
+        throw new IllegalArgumentException(name);
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/DeserializedRawSrm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/DeserializedRawSrm.java
@@ -1,4 +1,0 @@
-package us.dot.its.jpo.geojsonconverter.pojos.geojson.srm;
-
-public class DeserializedRawSrm {
-}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/DeserializedRawSrm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/DeserializedRawSrm.java
@@ -1,0 +1,4 @@
+package us.dot.its.jpo.geojsonconverter.pojos.geojson.srm;
+
+public class DeserializedRawSrm {
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedPriorityRequestType.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedPriorityRequestType.java
@@ -1,0 +1,34 @@
+package us.dot.its.jpo.geojsonconverter.pojos.geojson.srm;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
+
+@Getter
+public enum ProcessedPriorityRequestType {
+    PRIORITYREQUESTTYPERESERVED(0, "priorityRequestTypeReserved"),
+    PRIORITYREQUEST(1, "priorityRequest"),
+    PRIORITYREQUESTUPDATE(2, "priorityRequestUpdate"),
+    PRIORITYCANCELLATION(3, "priorityCancellation");
+
+    private final int index;
+    private final String name;
+
+    private ProcessedPriorityRequestType(int index, String name) {
+        this.index = index;
+        this.name = name;
+    }
+
+    public static ProcessedPriorityRequestType fromName(String name) {
+        if (StringUtils.isBlank(name)) {
+            return null;
+        }
+        for (ProcessedPriorityRequestType enumValue : ProcessedPriorityRequestType.values()) {
+            if (Objects.equals(enumValue.getName(), name)) {
+                return enumValue;
+            }
+        }
+        throw new IllegalArgumentException(name);
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedSignalRequest.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedSignalRequest.java
@@ -1,5 +1,6 @@
 package us.dot.its.jpo.geojsonconverter.pojos.geojson.srm;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 /**
  * A SignalRuest within a ProcessedSrm.
@@ -44,5 +46,6 @@ public class ProcessedSignalRequest {
 
     // Timestamp of the DF_SignalRequestPackage
     private ZonedDateTime estimatedTimeOfArrival;
-    private Duration estimatedTimeOfArrivalDuration;
+
+    private Duration estimatedTimeOfArrivalDurationSeconds;
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedSignalRequest.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedSignalRequest.java
@@ -1,0 +1,48 @@
+package us.dot.its.jpo.geojsonconverter.pojos.geojson.srm;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Generated;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+
+/**
+ * A SignalRuest within a ProcessedSrm.
+ * Includes information about the request, but does not include
+ * requestor information or location.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Generated
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Slf4j
+public class ProcessedSignalRequest {
+    // Requestor Description properties
+    private Integer region;
+    private Integer intersectionId;
+    private Integer requestID;
+    private ProcessedPriorityRequestType priorityRequestType;
+
+    // Intersection Access Point may be either LaneID, ApproachID, or LaneConnectionID
+
+    // Inbound access point is required
+    private Integer inboundLaneID;
+    private Integer inboundApproachID;
+    private Integer inboundLaneConnectionID;
+
+    // Outbound access point is optional
+    private Integer outboundLaneID;
+    private Integer outboundApproachID;
+    private Integer outboundLaneConnectionID;
+
+    // Timestamp of the DF_SignalRequestPackage
+    private ZonedDateTime estimatedTimeOfArrival;
+    private Duration estimatedTimeOfArrivalDuration;
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedSrm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedSrm.java
@@ -10,10 +10,13 @@ import us.dot.its.jpo.geojsonconverter.pojos.geojson.BaseFeature;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
 
 /**
- * A point feature representing a processed J2735 SignalRequestMessageFrame.
- * <p>The geometry is the point location of the vehicle that broadcast the SRM.
- * Note, however, that position is optional in J2735 DF_RequestorDescription, so the geometry
+ * A point feature representing a processed J2735 MSG_SignalRequestMessage.
+ * <p>Similar to BSMs, the geometry is the point location of the vehicle that broadcast the SRM.</p>
+ * <p>But note that unlike BSMs, the position is optional in J2735 DF_RequestorDescription, so the geometry
  * may be null.</p>
+ * <p>The SRM may contain multiple requests that may represent multiple lane connections of the
+ * same intersection, or multiple intersections.  These are represented by a list of
+ * {@link ProcessedSignalRequest}s in the {@link SrmProperties}</p>
  */
 @Generated
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedSrm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedSrm.java
@@ -1,0 +1,25 @@
+package us.dot.its.jpo.geojsonconverter.pojos.geojson.srm;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Generated;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.BaseFeature;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
+
+/**
+ * A point feature representing a processed J2735 SignalRequestMessageFrame.
+ * <p>The geometry is the point location of the vehicle that broadcast the SRM</p>
+ */
+@Generated
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProcessedSrm extends BaseFeature<Void, Point, SrmProperties> {
+    @JsonCreator
+    public ProcessedSrm(@JsonProperty("geometry") Point geometry,
+                        @JsonProperty("properties") SrmProperties srmProperties) {
+        super(null, geometry, srmProperties);
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedSrm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedSrm.java
@@ -11,7 +11,9 @@ import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
 
 /**
  * A point feature representing a processed J2735 SignalRequestMessageFrame.
- * <p>The geometry is the point location of the vehicle that broadcast the SRM</p>
+ * <p>The geometry is the point location of the vehicle that broadcast the SRM.
+ * Note, however, that position is optional in J2735 DF_RequestorDescription, so the geometry
+ * may be null.</p>
  */
 @Generated
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedTransitVehicleOccupancy.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedTransitVehicleOccupancy.java
@@ -1,0 +1,39 @@
+package us.dot.its.jpo.geojsonconverter.pojos.geojson.srm;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import us.dot.its.jpo.geojsonconverter.pojos.common.ProcessedSpeedLimitType;
+
+import java.util.Objects;
+
+@Getter
+public enum ProcessedTransitVehicleOccupancy {
+    OCCUPANCYUNKNOWN(0, "occupancyUnknown"),
+    OCCUPANCYEMPTY(1, "occupancyEmpty"),
+    OCCUPANCYVERYLOW(2, "occupancyVeryLow"),
+    OCCUPANCYLOW(3, "occupancyLow"),
+    OCCUPANCYMED(4, "occupancyMed"),
+    OCCUPANCYHIGH(5, "occupancyHigh"),
+    OCCUPANCYNEARLYFULL(6, "occupancyNearlyFull"),
+    OCCUPANCYFULL(7, "occupancyFull");
+
+    private final int index;
+    private final String name;
+
+    private ProcessedTransitVehicleOccupancy(int index, String name) {
+        this.index = index;
+        this.name = name;
+    }
+
+    public static ProcessedTransitVehicleOccupancy fromName(String name) {
+        if (StringUtils.isBlank(name)) {
+            return null;
+        }
+        for (ProcessedTransitVehicleOccupancy enumValue : ProcessedTransitVehicleOccupancy.values()) {
+            if (Objects.equals(enumValue.getName(), name)) {
+                return enumValue;
+            }
+        }
+        throw new IllegalArgumentException(name);
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedTransitVehicleStatus.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/ProcessedTransitVehicleStatus.java
@@ -1,0 +1,9 @@
+package us.dot.its.jpo.geojsonconverter.pojos.geojson.srm;
+
+import us.dot.its.jpo.geojsonconverter.pojos.ProcessedBitstring;
+
+public class ProcessedTransitVehicleStatus extends ProcessedBitstring {
+    public ProcessedTransitVehicleStatus() {
+        super("loading", "anADAuse", "aBikeLoad", "doorOpen", "charging", "atStopLine");
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
@@ -1,4 +1,84 @@
 package us.dot.its.jpo.geojsonconverter.pojos.geojson.srm;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Generated;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import us.dot.its.jpo.geojsonconverter.pojos.common.*;
+
+import java.time.ZonedDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Generated
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Slf4j
 public class SrmProperties {
+
+    // Metadata properties
+    private int schemaVersion = -1;
+    private final String messageType = "SRM";
+    private ZonedDateTime odeReceivedAt;
+    private String originIp;
+    private String asn1;
+
+    // Payload properties
+
+    // Top-level timestamp of the SRM
+    private ZonedDateTime timeStamp;
+
+    // Signal Request Package properties
+
+    // Timestamp of the DF_SignalRequestPackage
+    private ZonedDateTime requestTimeStamp;
+    private Integer region;
+    private Integer intersectionId;
+    private Integer requestID;
+    private ProcessedPriorityRequestType priorityRequestType;
+
+    // Intersection Access Point may be either LaneID, ApproachID, or LaneConnectionID
+
+    // Inbound access point is required
+    private Integer inboundLaneID;
+    private Integer inboundApproachID;
+    private Integer inboundLaneConnectionID;
+
+    // Outbound access point is optional
+    private Integer outboundLaneID;
+    private Integer outboundApproachID;
+    private Integer outboundLaneConnectionID;
+
+    // Fields from DF_RequestorDescription
+    // VehicleID is required.  It may be a TemporaryID or StationID.
+    private String vehicleID;
+
+    // RequestorType
+    private ProcessedBasicVehicleRole role;
+    private ProcessedRequestSubRole subrole;
+    private ProcessedRequestImportanceLevel importanceLevel;
+    private Integer iso3833VehicleType;
+    private ProcessedVehicleType hpmsType;
+
+    // Fields from RequestorPositionVector
+    private Double latitude;
+    private Double longitude;
+    private Double elevation;
+    private Double heading;
+    private ProcessedTransmissionState transmission;
+    private Double speed;
+
+    // Descriptive name is optional
+    private String descriptiveName;
+
+    private ProcessedTransitVehicleStatus transitStatus;
+    private ProcessedTransitVehicleOccupancy transitOccupancy;
+
+    // DE_DeltaTime
+    private Integer transitSchedule;
+
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
@@ -1,0 +1,4 @@
+package us.dot.its.jpo.geojsonconverter.pojos.geojson.srm;
+
+public class SrmProperties {
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
@@ -7,10 +7,12 @@ import lombok.Data;
 import lombok.Generated;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import us.dot.its.jpo.geojsonconverter.pojos.ProcessedValidationMessage;
 import us.dot.its.jpo.geojsonconverter.pojos.common.*;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -63,5 +65,32 @@ public class SrmProperties {
     private Duration transitSchedule;
 
     private List<ProcessedSignalRequest> requests;
+
+    /* -----------------------------------------------------------------------
+        Validation
+    ------------------------------------------------------------------------*/
+    private List<ProcessedValidationMessage> validationMessages = new ArrayList<>();
+
+    private boolean cti4501Conformant = true;
+
+    public void addValidationMessage(ProcessedValidationMessage message) {
+        if (validationMessages == null) {
+            validationMessages = new ArrayList<ProcessedValidationMessage>();
+        }
+        validationMessages.add(message);
+    }
+
+    public void addValidationMessages(List<ProcessedValidationMessage> messages) {
+        if (validationMessages == null) {
+            validationMessages = new ArrayList<>();
+        }
+        validationMessages.addAll(messages);
+    }
+
+    public void addValidationMessage(String message) {
+        var validationMessage = new ProcessedValidationMessage();
+        validationMessage.setMessage(message);
+        addValidationMessage(validationMessage);
+    }
 
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
@@ -11,6 +11,7 @@ import us.dot.its.jpo.geojsonconverter.pojos.common.*;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -33,26 +34,6 @@ public class SrmProperties {
     // Top-level timestamp of the SignalRequestMessage
     private ZonedDateTime timeStamp;
     private Integer sequenceNumber;
-
-    // Signal Request Package properties
-
-
-    private Integer region;
-    private Integer intersectionId;
-    private Integer requestID;
-    private ProcessedPriorityRequestType priorityRequestType;
-
-    // Intersection Access Point may be either LaneID, ApproachID, or LaneConnectionID
-
-    // Inbound access point is required
-    private Integer inboundLaneID;
-    private Integer inboundApproachID;
-    private Integer inboundLaneConnectionID;
-
-    // Outbound access point is optional
-    private Integer outboundLaneID;
-    private Integer outboundApproachID;
-    private Integer outboundLaneConnectionID;
 
     // Fields from DF_RequestorDescription
     // VehicleID is required.  It may be a TemporaryID or StationID.
@@ -81,8 +62,6 @@ public class SrmProperties {
     // DE_DeltaTime
     private Duration transitSchedule;
 
-    // Timestamp of the DF_SignalRequestPackage
-    private ZonedDateTime estimatedTimeOfArrival;
-    private Duration estimatedTimeOfArrivalDuration;
+    private List<ProcessedSignalRequest> requests;
 
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
@@ -31,6 +31,7 @@ public class SrmProperties {
 
     // Top-level timestamp of the SRM
     private ZonedDateTime timeStamp;
+    private Integer sequenceNumber;
 
     // Signal Request Package properties
 

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import us.dot.its.jpo.geojsonconverter.pojos.common.*;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 
 @Data
@@ -29,14 +30,13 @@ public class SrmProperties {
 
     // Payload properties
 
-    // Top-level timestamp of the SRM
+    // Top-level timestamp of the SignalRequestMessage
     private ZonedDateTime timeStamp;
     private Integer sequenceNumber;
 
     // Signal Request Package properties
 
-    // Timestamp of the DF_SignalRequestPackage
-    private ZonedDateTime requestTimeStamp;
+
     private Integer region;
     private Integer intersectionId;
     private Integer requestID;
@@ -73,13 +73,16 @@ public class SrmProperties {
     private ProcessedTransmissionState transmission;
     private Double speed;
 
-    // Descriptive name is optional
-    private String descriptiveName;
-
+    private String name;
+    private String routeName;
     private ProcessedTransitVehicleStatus transitStatus;
     private ProcessedTransitVehicleOccupancy transitOccupancy;
 
     // DE_DeltaTime
-    private Integer transitSchedule;
+    private Duration transitSchedule;
+
+    // Timestamp of the DF_SignalRequestPackage
+    private ZonedDateTime estimatedTimeOfArrival;
+    private Duration estimatedTimeOfArrivalDuration;
 
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/srm/SrmProperties.java
@@ -54,7 +54,10 @@ public class SrmProperties {
     private Double elevation;
     private Double heading;
     private ProcessedTransmissionState transmission;
-    private Double speed;
+    /**
+     * Speed in meters/second.
+     */
+    private Double speedMetersPerSecond;
 
     private String name;
     private String routeName;
@@ -62,7 +65,7 @@ public class SrmProperties {
     private ProcessedTransitVehicleOccupancy transitOccupancy;
 
     // DE_DeltaTime
-    private Duration transitSchedule;
+    private Duration transitScheduleSeconds;
 
     private List<ProcessedSignalRequest> requests;
 
@@ -70,8 +73,6 @@ public class SrmProperties {
         Validation
     ------------------------------------------------------------------------*/
     private List<ProcessedValidationMessage> validationMessages = new ArrayList<>();
-
-    private boolean cti4501Conformant = true;
 
     public void addValidationMessage(ProcessedValidationMessage message) {
         if (validationMessages == null) {

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/DeserializedRawSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/DeserializedRawSsm.java
@@ -1,0 +1,4 @@
+package us.dot.its.jpo.geojsonconverter.pojos.ssm;
+
+public class DeserializedRawSsm {
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/DeserializedRawSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/DeserializedRawSsm.java
@@ -1,4 +1,0 @@
-package us.dot.its.jpo.geojsonconverter.pojos.ssm;
-
-public class DeserializedRawSsm {
-}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSignalStatus.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSignalStatus.java
@@ -1,0 +1,60 @@
+package us.dot.its.jpo.geojsonconverter.pojos.ssm;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Generated;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import us.dot.its.jpo.geojsonconverter.pojos.common.*;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+
+/**
+ * A signal status response within a {@link ProcessedSsm}.
+ * Represents a flattened view of an individual DF_SignalStatusPackage frame containing a response to one specific
+ * request from a vehicle, and it's parent DF_SignalStatus, representing an intersection.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Generated
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Slf4j
+public class ProcessedSignalStatus {
+
+    // Fields from DF_SignalRequesterInfo
+    private String vehicleID;
+    private Integer requestID;
+    private Integer requesterSequenceNumber;
+    private ProcessedBasicVehicleRole requesterRole;
+    private ProcessedRequestSubRole requesterSubrole;
+    private ProcessedRequestImportanceLevel requestImportanceLevel;
+    private Integer requesterIso3833VehicleType;
+    private ProcessedVehicleType requesterHpmsType;
+
+    // Fields from inboundOn IntersectionAccessPoint
+    private Integer inboundOnLaneID;
+    private Integer inboundOnApproachID;
+    private Integer inboundOnLaneConnectionID;
+
+    // Fields from outboundOn IntersectionAccessPoint
+    private Integer outboundOnLaneID;
+    private Integer outboundOnApproachID;
+    private Integer outboundOnLaneConnectionID;
+
+    /**
+     * ETA from the SignalStatusPackage MinuteOfYear and second/DSecond fields
+     */
+    private ZonedDateTime estimatedTimeOfArrival;
+
+    /**
+     * From DF_SignalStatusPackage.duration
+     */
+    private Duration estimatedTimeOfArrivalDuration;
+
+    private ProcessedPrioritizationResponseStatus status;
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSignalStatus.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSignalStatus.java
@@ -1,5 +1,6 @@
 package us.dot.its.jpo.geojsonconverter.pojos.ssm;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
@@ -54,7 +55,7 @@ public class ProcessedSignalStatus {
     /**
      * From DF_SignalStatusPackage.duration
      */
-    private Duration estimatedTimeOfArrivalDuration;
+    private Duration estimatedTimeOfArrivalDurationSeconds;
 
     private ProcessedPrioritizationResponseStatus status;
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
@@ -6,10 +6,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Generated;
 import lombok.NoArgsConstructor;
+import us.dot.its.jpo.geojsonconverter.pojos.ProcessedValidationMessage;
 import us.dot.its.jpo.geojsonconverter.pojos.common.*;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 /**
  * A processed J2735 SignalStatusMessage.
@@ -25,12 +27,14 @@ import java.time.ZonedDateTime;
 public class ProcessedSsm {
     private int schemaVersion = -1;
     private final String messageType = "SSM";
+    private String asn1;
+    private List<ProcessedValidationMessage> validationMessages;
 
     // ------------------------------------------------------------------------
     // Metadata from the ODE header
     private ZonedDateTime odeReceivedAt;
     private String originIp;
-    private String asn1;
+
 
     // ------------------------------------------------------------------------
     // Data from the MessageFrame payload

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
@@ -11,6 +11,7 @@ import us.dot.its.jpo.geojsonconverter.pojos.common.*;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -33,7 +34,6 @@ public class ProcessedSsm {
     private int schemaVersion = -1;
     private final String messageType = "SSM";
     private String asn1;
-    private List<ProcessedValidationMessage> validationMessages;
 
     // ------------------------------------------------------------------------
     // Metadata from the ODE header
@@ -70,4 +70,31 @@ public class ProcessedSsm {
     private Integer intersectionId;
 
     private List<ProcessedSignalStatus> statusList;
+
+    /* -----------------------------------------------------------------------
+        Validation
+    ------------------------------------------------------------------------*/
+    private List<ProcessedValidationMessage> validationMessages = new ArrayList<>();
+
+    private boolean cti4501Conformant = true;
+
+    public void addValidationMessage(ProcessedValidationMessage message) {
+        if (validationMessages == null) {
+            validationMessages = new ArrayList<ProcessedValidationMessage>();
+        }
+        validationMessages.add(message);
+    }
+
+    public void addValidationMessages(List<ProcessedValidationMessage> messages) {
+        if (validationMessages == null) {
+            validationMessages = new ArrayList<>();
+        }
+        validationMessages.addAll(messages);
+    }
+
+    public void addValidationMessage(String message) {
+        var validationMessage = new ProcessedValidationMessage();
+        validationMessage.setMessage(message);
+        addValidationMessage(validationMessage);
+    }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
@@ -19,6 +19,9 @@ import java.util.List;
  * <p>Similar to a SPAT, the SSM is associated with an intersection, but does not contain any geographic information
  * itself, therefore this is a plain Java object, not a GeoJSON object.  It must be matched with a corresponding MAP
  * message to find the intersection location.</p>
+ * <p>It is possible, in theory, for an SSM to contain SignalRequests for more than one intersection, but that
+ * scenario is not supported by this library.  If an SSM containing multiple intersection were received, all but the
+ * first one would be discarded by the converter (similar to the behavior for SPATs).</p>
  */
 @Data
 @NoArgsConstructor
@@ -66,35 +69,5 @@ public class ProcessedSsm {
      */
     private Integer intersectionId;
 
-    // Fields from DF_SignalRequesterInfo
-    private String vehicleID;
-    private Integer requestID;
-    private Integer requesterSequenceNumber;
-    private ProcessedBasicVehicleRole requesterRole;
-    private ProcessedRequestSubRole requesterSubrole;
-    private ProcessedRequestImportanceLevel requestImportanceLevel;
-    private Integer requesterIso3833VehicleType;
-    private ProcessedVehicleType requesterHpmsType;
-
-    // Fields from inboundOn IntersectionAccessPoint
-    private Integer inboundOnLaneID;
-    private Integer inboundOnApproachID;
-    private Integer inboundOnLaneConnectionID;
-
-    // Fields from outboundOn IntersectionAccessPoint
-    private Integer outboundOnLaneID;
-    private Integer outboundOnApproachID;
-    private Integer outboundOnLaneConnectionID;
-
-    /**
-     * ETA from the SignalStatusPackage MinuteOfYear and second/DSecond fields
-     */
-    private ZonedDateTime estimatedTimeOfArrival;
-
-    /**
-     * From DF_SignalStatusPackage.duration
-     */
-    private Duration estimatedTimeOfArrivalDuration;
-
-    private ProcessedPrioritizationResponseStatus status;
+    private List<ProcessedSignalStatus> statusList;
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
@@ -1,0 +1,17 @@
+package us.dot.its.jpo.geojsonconverter.pojos.ssm;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Generated;
+
+/**
+ * A processed J2735 SignalStatusMessageFrame.
+ * <p>Similar to a SPAT, the SSM is associated with an intersection, but does not contain geographic information
+ * itself.</p>
+ */
+@Generated
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProcessedSsm {
+
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
@@ -14,9 +14,11 @@ import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
- * A processed J2735 SignalStatusMessage.
- * <p>Similar to a SPAT, the SSM is associated with an intersection, but does not contain geographic information
- * itself.</p>
+ * A Java object representing a processed J2735 MSG_SignalStatusMessage.
+ * <p>The SSM may contain responses to multiple requests from multiple vehicles.</p>
+ * <p>Similar to a SPAT, the SSM is associated with an intersection, but does not contain any geographic information
+ * itself, therefore this is a plain Java object, not a GeoJSON object.  It must be matched with a corresponding MAP
+ * message to find the intersection location.</p>
  */
 @Data
 @NoArgsConstructor

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
@@ -76,8 +76,6 @@ public class ProcessedSsm {
     ------------------------------------------------------------------------*/
     private List<ProcessedValidationMessage> validationMessages = new ArrayList<>();
 
-    private boolean cti4501Conformant = true;
-
     public void addValidationMessage(ProcessedValidationMessage message) {
         if (validationMessages == null) {
             validationMessages = new ArrayList<ProcessedValidationMessage>();

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
@@ -6,11 +6,13 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Generated;
 import lombok.NoArgsConstructor;
+import us.dot.its.jpo.geojsonconverter.pojos.common.*;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 
 /**
- * A processed J2735 SignalStatusMessageFrame.
+ * A processed J2735 SignalStatusMessage.
  * <p>Similar to a SPAT, the SSM is associated with an intersection, but does not contain geographic information
  * itself.</p>
  */
@@ -24,21 +26,69 @@ public class ProcessedSsm {
     private int schemaVersion = -1;
     private final String messageType = "SSM";
 
+    // ------------------------------------------------------------------------
     // Metadata from the ODE header
     private ZonedDateTime odeReceivedAt;
     private String originIp;
     private String asn1;
 
+    // ------------------------------------------------------------------------
     // Data from the MessageFrame payload
-    private Integer region;
-    private Integer intersectionId;
-    private ZonedDateTime utcTimeStamp;
+
+    /**
+     * Top-level timestamp of MSG_SignalStatusMessage
+      */
+    private ZonedDateTime timeStamp;
+
+    /**
+     * Top-level sequence number (DE_MsgCount) of MSG_SignalStatusMessage
+     */
     private Integer sequenceNumber;
+
+    /**
+     * Sequence number (DE_MsgCount) of the DF_SignalStatus frame
+     */
     private Integer statusSequenceNumber;
-    private String requesterId;
-    private Integer requestId;
+
+    /**
+     * DE_RoadRequlatorID
+     */
+    private Integer region;
+
+    /**
+     * DE_IntersectionID
+     */
+    private Integer intersectionId;
+
+    // Fields from DF_SignalRequesterInfo
+    private String vehicleID;
+    private Integer requestID;
     private Integer requesterSequenceNumber;
-    private String requesterRole;
-    private Integer inboundLaneId;
-    private String status;
+    private ProcessedBasicVehicleRole requesterRole;
+    private ProcessedRequestSubRole requesterSubrole;
+    private ProcessedRequestImportanceLevel requestImportanceLevel;
+    private Integer requesterIso3833VehicleType;
+    private ProcessedVehicleType requesterHpmsType;
+
+    // Fields from inboundOn IntersectionAccessPoint
+    private Integer inboundOnLaneID;
+    private Integer inboundOnApproachID;
+    private Integer inboundOnLaneConnectionID;
+
+    // Fields from outboundOn IntersectionAccessPoint
+    private Integer outboundOnLaneID;
+    private Integer outboundOnApproachID;
+    private Integer outboundOnLaneConnectionID;
+
+    /**
+     * ETA from the SignalStatusPackage MinuteOfYear and second/DSecond fields
+     */
+    private ZonedDateTime estimatedTimeOfArrival;
+
+    /**
+     * From DF_SignalStatusPackage.duration
+     */
+    private Duration estimatedTimeOfArrivalDuration;
+
+    private ProcessedPrioritizationResponseStatus status;
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
@@ -2,16 +2,43 @@ package us.dot.its.jpo.geojsonconverter.pojos.ssm;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Generated;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
 
 /**
  * A processed J2735 SignalStatusMessageFrame.
  * <p>Similar to a SPAT, the SSM is associated with an intersection, but does not contain geographic information
  * itself.</p>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 @Generated
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ProcessedSsm {
+    private int schemaVersion = -1;
+    private final String messageType = "SSM";
 
+    // Metadata from the ODE header
+    private ZonedDateTime odeReceivedAt;
+    private String originIp;
+    private String asn1;
+
+    // Data from the MessageFrame payload
+    private Integer region;
+    private Integer intersectionId;
+    private ZonedDateTime utcTimeStamp;
+    private Integer sequenceNumber;
+    private Integer statusSequenceNumber;
+    private String requesterId;
+    private Integer requestId;
+    private Integer requesterSequenceNumber;
+    private String requesterRole;
+    private Integer inboundLaneId;
+    private String status;
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/SsmProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/SsmProperties.java
@@ -1,4 +1,0 @@
-package us.dot.its.jpo.geojsonconverter.pojos.ssm;
-
-public class SsmProperties {
-}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/SsmProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/SsmProperties.java
@@ -1,0 +1,4 @@
+package us.dot.its.jpo.geojsonconverter.pojos.ssm;
+
+public class SsmProperties {
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/serialization/JsonSerdes.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/serialization/JsonSerdes.java
@@ -6,11 +6,13 @@ import us.dot.its.jpo.geojsonconverter.partitioner.RsuStationIdKey;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.bsm.ProcessedBsm;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuPsmIdKey;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.rtcm.ProcessedRTCM;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
 import us.dot.its.jpo.geojsonconverter.pojos.spat.*;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.psm.ProcessedPsm;
+import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
 import us.dot.its.jpo.geojsonconverter.serialization.deserializers.*;
 import us.dot.its.jpo.geojsonconverter.serialization.serializers.*;
 import us.dot.its.jpo.ode.model.OdeMessageFrameData;
@@ -69,5 +71,13 @@ public class JsonSerdes {
 
     public static Serde<ProcessedRTCM> ProcessedRTCM() {
         return Serdes.serdeFrom(new JsonSerializer<>(), new JsonDeserializer<>(ProcessedRTCM.class));
+    }
+
+    public static Serde<ProcessedSsm> ProcessedSsm() {
+        return Serdes.serdeFrom(new JsonSerializer<>(), new JsonDeserializer<>(ProcessedSsm.class));
+    }
+
+    public static Serde<ProcessedSrm> ProcessedSrm() {
+        return Serdes.serdeFrom(new JsonSerializer<>(), new JsonDeserializer<>(ProcessedSrm.class));
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/serialization/JsonSerdes.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/serialization/JsonSerdes.java
@@ -1,10 +1,7 @@
 package us.dot.its.jpo.geojsonconverter.serialization;
 
-import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
-import us.dot.its.jpo.geojsonconverter.partitioner.RsuLogKey;
-import us.dot.its.jpo.geojsonconverter.partitioner.RsuStationIdKey;
+import us.dot.its.jpo.geojsonconverter.partitioner.*;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.bsm.ProcessedBsm;
-import us.dot.its.jpo.geojsonconverter.partitioner.RsuPsmIdKey;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.rtcm.ProcessedRTCM;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
 import us.dot.its.jpo.geojsonconverter.pojos.spat.*;
@@ -79,5 +76,9 @@ public class JsonSerdes {
 
     public static Serde<ProcessedSrm> ProcessedSrm() {
         return Serdes.serdeFrom(new JsonSerializer<>(), new JsonDeserializer<>(ProcessedSrm.class));
+    }
+
+    public static Serde<RsuVehicleIdKey> RsuVehicleIdKey() {
+        return Serdes.serdeFrom(new JsonSerializer<>(), new JsonDeserializer<>(RsuVehicleIdKey.class));
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/utils/ProcessedSchemaVersions.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/utils/ProcessedSchemaVersions.java
@@ -11,4 +11,6 @@ public class ProcessedSchemaVersions {
     public static final int PROCESSED_SPAT_SCHEMA_VERSION = 2;
     public static final int PROCESSED_PSM_SCHEMA_VERSION = 2;
     public static final int PROCESSED_RTCM_SCHEMA_VERSION = 1;
+    public static final int PROCESSED_SSM_SCHEMA_VERSION = 1;
+    public static final int PROCESSED_SRM_SCHEMA_VERSION = 1;
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/utils/SchemaGeneratorUtility.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/utils/SchemaGeneratorUtility.java
@@ -8,7 +8,10 @@ import us.dot.its.jpo.geojsonconverter.pojos.geojson.bsm.ProcessedBsm;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.psm.ProcessedPsm;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.rtcm.ProcessedRTCM;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
 import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
+import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -19,7 +22,8 @@ public class SchemaGeneratorUtility {
         try {
             // Define the classes for which to generate schemas
             Class<?>[] targetClasses =
-                    {ProcessedPsm.class, ProcessedBsm.class, ProcessedMap.class, ProcessedSpat.class, ProcessedRTCM.class};
+                    {ProcessedPsm.class, ProcessedBsm.class, ProcessedMap.class, ProcessedSpat.class, ProcessedRTCM.class,
+                    ProcessedSrm.class, ProcessedSsm.class};
 
             ObjectMapper objectMapper = new ObjectMapper();
 

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/AbstractJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/AbstractJsonValidator.java
@@ -3,6 +3,8 @@ package us.dot.its.jpo.geojsonconverter.validator;
 import java.io.IOException;
 import java.util.Set;
 
+import lombok.Getter;
+import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -11,36 +13,26 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.ValidationMessage;
 import com.networknt.schema.SpecVersion;
+import org.springframework.core.io.ResourceLoader;
 
 /**
  * Class for a validator to validate a JSON document against a
  * schema and report all errors.
- * 
- * Annotate implementing classes with <code>@Service</code> to inject with Spring DI.
  */
 public abstract class AbstractJsonValidator {
 
      /**
-     * @param jsonSchemaResource The json schema file in resources/schemas.  
-     * Add an <code>@Value("${schema.resourceName}")</code> annotation to this argument
-     * in implementing classes to specify the schema location.
+     * @param schemaLocation The classpath to the schema location
+     * For example: ""classpath:schemas/srm.schema.json"
      */
-    protected AbstractJsonValidator(Resource jsonSchemaResource) {
-        this.jsonSchemaResource = jsonSchemaResource;
+    protected AbstractJsonValidator(String schemaLocation) {
+        this.jsonSchemaResource = loadJsonSchemaResource(schemaLocation);
     }
 
     private final ObjectMapper mapper = new ObjectMapper();
+    @Getter
     private final Resource jsonSchemaResource;
     private JsonSchema jsonSchema;
-
-    /**
-     * The resource where the json schema file is
-     * 
-     * @return Resource
-     */
-    public Resource getJsonSchemaResource() {
-        return jsonSchemaResource;
-    }
 
 
     public JsonSchema getJsonSchema() throws IOException {
@@ -63,7 +55,7 @@ public abstract class AbstractJsonValidator {
             JsonNode node = mapper.readTree(json);
             Set<ValidationMessage> validationMessages = getJsonSchema().validate(node);
             result.addValidationMessages(validationMessages);
-        } catch (IOException e) {
+        } catch (Exception e) {
             result.addException(e);
         }
         return result;
@@ -75,11 +67,19 @@ public abstract class AbstractJsonValidator {
             JsonNode node = mapper.readTree(jsonBytes);
             Set<ValidationMessage> validationMessages = getJsonSchema().validate(node);
             result.addValidationMessages(validationMessages);
-        } catch (IOException e) {
+        } catch (Exception e) {
             result.addException(e);
 
         }
         return result;
+    }
+
+    private Resource loadJsonSchemaResource(String schemaLocation) {
+        ResourceLoader resourceLoader = new DefaultResourceLoader();
+        if (schemaLocation != null) {
+            return resourceLoader.getResource(schemaLocation);
+        }
+        return null;
     }
     
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/BsmJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/BsmJsonValidator.java
@@ -9,10 +9,15 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class BsmJsonValidator extends AbstractJsonValidator {
+
+    public BsmJsonValidator() {
+        super("classpath:schemas/bsm.schema.json");
+    }
+
     /**
-     * @param jsonSchemaResource The json schema file in resources/schemas.  Injected by Spring DI.
+     * @param schemaLocation The json schema classpath
      */
-    public BsmJsonValidator(@Value("${schema.bsm}") Resource jsonSchemaResource) {
-        super(jsonSchemaResource);
+    public BsmJsonValidator(String schemaLocation) {
+        super(schemaLocation);
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/MapJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/MapJsonValidator.java
@@ -11,11 +11,15 @@ import org.springframework.stereotype.Service;
 @Service
 public class MapJsonValidator extends AbstractJsonValidator  {
 
+    public MapJsonValidator() {
+        super("classpath:schemas/map.schema.json");
+    }
+
     /**
-     * @param jsonSchemaResource The json schema file in resources/schemas.  Injected by Spring DI.
+     * @param schemaLocation The json schema classpath
      */
-    public MapJsonValidator(@Value("${schema.map}") Resource jsonSchemaResource) {
-        super(jsonSchemaResource);
+    public MapJsonValidator(String schemaLocation) {
+        super(schemaLocation);
     }
 
 

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/PsmJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/PsmJsonValidator.java
@@ -9,10 +9,16 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class PsmJsonValidator extends AbstractJsonValidator {
-    /**
-     * @param jsonSchemaResource The json schema file in resources/schemas.  Injected by Spring DI.
-     */
-    public PsmJsonValidator(@Value("${schema.psm}") Resource jsonSchemaResource) {
-        super(jsonSchemaResource);
+
+    public PsmJsonValidator() {
+        super("classpath:schemas/psm.schema.json");
     }
+
+    /**
+     * @param schemaLocation The json schema classpath
+     */
+    public PsmJsonValidator(String schemaLocation) {
+        super(schemaLocation);
+    }
+
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/RTCMJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/RTCMJsonValidator.java
@@ -11,7 +11,14 @@ import org.springframework.stereotype.Service;
 @Service
 public class RTCMJsonValidator extends AbstractJsonValidator {
 
-    public RTCMJsonValidator(@Value("${schema.rtcm}") Resource jsonSchemaResource) {
-        super(jsonSchemaResource);
+    public RTCMJsonValidator() {
+        super("classpath:schemas/srm.schema.json");
+    }
+
+    /**
+     * @param schemaLocation The json schema classpath
+     */
+    public RTCMJsonValidator(String schemaLocation) {
+        super(schemaLocation);
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SpatJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SpatJsonValidator.java
@@ -10,11 +10,15 @@ import org.springframework.stereotype.Service;
 @Service
 public class SpatJsonValidator extends AbstractJsonValidator {
 
+    public SpatJsonValidator() {
+        super("classpath:schemas/spat.schema.json");
+    }
+
     /**
-     * @param jsonSchemaResource The json schema file in resources/schemas.  Injected by Spring DI.
+     * @param schemaLocation The json schema classpath
      */
-    public SpatJsonValidator(@Value("${schema.spat}") Resource jsonSchemaResource) {
-        super(jsonSchemaResource);
+    public SpatJsonValidator(String schemaLocation) {
+        super(schemaLocation);
     }
     
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SrmJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SrmJsonValidator.java
@@ -1,7 +1,9 @@
 package us.dot.its.jpo.geojsonconverter.validator;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
 
 /**
@@ -9,11 +11,17 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class SrmJsonValidator extends AbstractJsonValidator {
-    /**
-     * @param jsonSchemaResource The json schema file in resources/schemas.
-     *                           Injected by Spring DI.
-     */
-    public SrmJsonValidator(@Value("${schema.srm}") Resource jsonSchemaResource) {
-        super(jsonSchemaResource);
+
+
+    public SrmJsonValidator() {
+        super("classpath:schemas/srm.schema.json");
     }
+
+    /**
+     * @param schemaLocation The json schema classpath
+     */
+    public SrmJsonValidator(String schemaLocation) {
+        super(schemaLocation);
+    }
+
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SrmJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SrmJsonValidator.java
@@ -1,0 +1,19 @@
+package us.dot.its.jpo.geojsonconverter.validator;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+/**
+ * JSON validator for SRM messages.
+ */
+@Service
+public class SrmJsonValidator extends AbstractJsonValidator {
+    /**
+     * @param jsonSchemaResource The json schema file in resources/schemas.
+     *                           Injected by Spring DI.
+     */
+    protected SrmJsonValidator(@Value("${schema.srm}") Resource jsonSchemaResource) {
+        super(jsonSchemaResource);
+    }
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SrmJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SrmJsonValidator.java
@@ -13,7 +13,7 @@ public class SrmJsonValidator extends AbstractJsonValidator {
      * @param jsonSchemaResource The json schema file in resources/schemas.
      *                           Injected by Spring DI.
      */
-    protected SrmJsonValidator(@Value("${schema.srm}") Resource jsonSchemaResource) {
+    public SrmJsonValidator(@Value("${schema.srm}") Resource jsonSchemaResource) {
         super(jsonSchemaResource);
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidator.java
@@ -2,10 +2,12 @@ package us.dot.its.jpo.geojsonconverter.validator;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
 
 /**
  * JSON validator for SSM Messages.
  */
+@Service
 public class SsmJsonValidator extends AbstractJsonValidator {
     /**
      * @param jsonSchemaResource The json schema file in resources/schemas.

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidator.java
@@ -9,10 +9,15 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class SsmJsonValidator extends AbstractJsonValidator {
+
+    public SsmJsonValidator() {
+        super("classpath:schemas/ssm.schema.json");
+    }
+
     /**
-     * @param jsonSchemaResource The json schema file in resources/schemas.
+     * @param schemaLocation The json schema classpath
      */
-    public SsmJsonValidator(@Value("${schema.ssm}") Resource jsonSchemaResource) {
-        super(jsonSchemaResource);
+    public SsmJsonValidator(String schemaLocation) {
+        super(schemaLocation);
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidator.java
@@ -12,7 +12,7 @@ public class SsmJsonValidator extends AbstractJsonValidator {
     /**
      * @param jsonSchemaResource The json schema file in resources/schemas.
      */
-    protected SsmJsonValidator(@Value("${schema.ssm}") Resource jsonSchemaResource) {
+    public SsmJsonValidator(@Value("${schema.ssm}") Resource jsonSchemaResource) {
         super(jsonSchemaResource);
     }
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidator.java
@@ -1,0 +1,16 @@
+package us.dot.its.jpo.geojsonconverter.validator;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+
+/**
+ * JSON validator for SSM Messages.
+ */
+public class SsmJsonValidator extends AbstractJsonValidator {
+    /**
+     * @param jsonSchemaResource The json schema file in resources/schemas.
+     */
+    protected SsmJsonValidator(@Value("${schema.ssm}") Resource jsonSchemaResource) {
+        super(jsonSchemaResource);
+    }
+}

--- a/jpo-geojsonconverter/src/main/resources/application.yaml
+++ b/jpo-geojsonconverter/src/main/resources/application.yaml
@@ -9,16 +9,6 @@ spring.main.web-application-type: servlet
 # Unused feature
 spring.groovy.template.check-template-location: false
 
-# JSON Schema resource paths
-schema:
-  bsm: classpath:schemas/bsm.schema.json
-  map: classpath:schemas/map.schema.json
-  spat: classpath:schemas/spat.schema.json
-  psm: classpath:schemas/psm.schema.json
-  rtcm: classpath:schemas/rtcm.schema.json
-  srm: classpath:schemas/srm.schema.json
-  ssm: classpath:schemas/ssm.schema.json
-
 # Geometry JSON output mode (GEOJSON_ONLY or WKT)
 geometry.output.mode: GEOJSON_ONLY
 

--- a/jpo-geojsonconverter/src/main/resources/application.yaml
+++ b/jpo-geojsonconverter/src/main/resources/application.yaml
@@ -16,6 +16,8 @@ schema:
   spat: classpath:schemas/spat.schema.json
   psm: classpath:schemas/psm.schema.json
   rtcm: classpath:schemas/rtcm.schema.json
+  srm: classpath:schemas/srm.schema.json
+  ssm: classpath:schemas/ssm.schema.json
 
 # Geometry JSON output mode (GEOJSON_ONLY or WKT)
 geometry.output.mode: GEOJSON_ONLY
@@ -44,6 +46,12 @@ kafka.topics:
     - name: topic.ProcessedRtcm
       cleanupPolicy: delete
       retentionMs: 300000
+    - name: topic.ProcessedSrm
+      cleanupPolicy: delete
+      retentionMs: 300000
+    - name: topic.ProcessedSsm
+      cleanupPolicy: delete
+      retentionMs: 300000
 
 # Jackson Properties
 spring.jackson.serialization.write-dates-as-timestamps: false
@@ -58,3 +66,7 @@ rtcm.full.decode: true
 geojsonconverter:
   kafka-topic-ode-rtcm-json: topic.OdeRtcmJson
   kafka-topic-processed-rtcm: topic.ProcessedRtcm
+  kafka-topic-ode-srm-json: topic.OdeSrmJson
+  kafka-topic-processed-srm: topic.ProcessedSrm
+  kafka-topic-ode-ssm-json: topic.OdeSsmJson
+  kafka-topic-processed-ssm: topic.ProcessedSsm

--- a/jpo-geojsonconverter/src/main/resources/schemas/processed-srm.schema.json
+++ b/jpo-geojsonconverter/src/main/resources/schemas/processed-srm.schema.json
@@ -1,0 +1,256 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "$defs" : {
+    "Duration" : {
+      "type" : "object",
+      "properties" : {
+        "seconds" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "Point-1" : {
+      "type" : "object",
+      "properties" : {
+        "bbox" : {
+          "type" : "array",
+          "items" : {
+            "type" : "number",
+            "format" : "double"
+          }
+        },
+        "coordinates" : {
+          "type" : "array",
+          "items" : {
+            "type" : "number",
+            "format" : "double"
+          }
+        }
+      }
+    },
+    "Point-2" : {
+      "$ref" : "#/$defs/Point-1",
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "const" : "Point"
+        }
+      },
+      "required" : [ "type" ]
+    },
+    "ProcessedBasicVehicleRole" : {
+      "type" : "string",
+      "enum" : [ "BASICVEHICLE", "PUBLICTRANSPORT", "SPECIALTRANSPORT", "DANGEROUSGOODS", "ROADWORK", "ROADRESCUE", "EMERGENCY", "SAFETYCAR", "NONE_UNKNOWN", "TRUCK", "MOTORCYCLE", "ROADSIDESOURCE", "POLICE", "FIRE", "AMBULANCE", "DOT", "TRANSIT", "SLOWMOVING", "STOPNGO", "CYCLIST", "PEDESTRIAN", "NONMOTORIZED", "MILITARY" ]
+    },
+    "ProcessedPriorityRequestType" : {
+      "type" : "string",
+      "enum" : [ "PRIORITYREQUESTTYPERESERVED", "PRIORITYREQUEST", "PRIORITYREQUESTUPDATE", "PRIORITYCANCELLATION" ]
+    },
+    "ProcessedRequestImportanceLevel" : {
+      "type" : "string",
+      "enum" : [ "REQUESTIMPORTANCELEVELUNKNOWN", "REQUESTIMPORTANCELEVEL1", "REQUESTIMPORTANCELEVEL2", "REQUESTIMPORTANCELEVEL3", "REQUESTIMPORTANCELEVEL4", "REQUESTIMPORTANCELEVEL5", "REQUESTIMPORTANCELEVEL6", "REQUESTIMPORTANCELEVEL7", "REQUESTIMPORTANCELEVEL8", "REQUESTIMPORTANCELEVEL9", "REQUESTIMPORTANCELEVEL10", "REQUESTIMPORTANCELEVEL11", "REQUESTIMPORTANCELEVEL12", "REQUESTIMPORTANCELEVEL13", "REQUESTIMPORTANCELEVEL14", "REQUESTIMPORTANCERESERVED" ]
+    },
+    "ProcessedRequestSubRole" : {
+      "type" : "string",
+      "enum" : [ "REQUESTSUBROLEUNKNOWN", "REQUESTSUBROLE1", "REQUESTSUBROLE2", "REQUESTSUBROLE3", "REQUESTSUBROLE4", "REQUESTSUBROLE5", "REQUESTSUBROLE6", "REQUESTSUBROLE7", "REQUESTSUBROLE8", "REQUESTSUBROLE9", "REQUESTSUBROLE10", "REQUESTSUBROLE11", "REQUESTSUBROLE12", "REQUESTSUBROLE13", "REQUESTSUBROLE14", "REQUESTSUBROLERESERVED" ]
+    },
+    "ProcessedSignalRequest" : {
+      "type" : "object",
+      "properties" : {
+        "estimatedTimeOfArrival" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "estimatedTimeOfArrivalDurationSeconds" : {
+          "$ref" : "#/$defs/Duration"
+        },
+        "inboundApproachID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inboundLaneConnectionID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inboundLaneID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "intersectionId" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "outboundApproachID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "outboundLaneConnectionID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "outboundLaneID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "priorityRequestType" : {
+          "$ref" : "#/$defs/ProcessedPriorityRequestType"
+        },
+        "region" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "requestID" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    },
+    "ProcessedTransitVehicleOccupancy" : {
+      "type" : "string",
+      "enum" : [ "OCCUPANCYUNKNOWN", "OCCUPANCYEMPTY", "OCCUPANCYVERYLOW", "OCCUPANCYLOW", "OCCUPANCYMED", "OCCUPANCYHIGH", "OCCUPANCYNEARLYFULL", "OCCUPANCYFULL" ]
+    },
+    "ProcessedTransitVehicleStatus" : {
+      "type" : "object"
+    },
+    "ProcessedTransmissionState" : {
+      "type" : "string",
+      "enum" : [ "NEUTRAL", "PARK", "FORWARDGEARS", "REVERSEGEARS", "RESERVED1", "RESERVED2", "RESERVED3", "UNAVAILABLE" ]
+    },
+    "ProcessedValidationMessage" : {
+      "type" : "object",
+      "properties" : {
+        "exception" : {
+          "type" : "string"
+        },
+        "jsonPath" : {
+          "type" : "string"
+        },
+        "message" : {
+          "type" : "string"
+        },
+        "schemaPath" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ProcessedVehicleType" : {
+      "type" : "string",
+      "enum" : [ "NONE", "UNKNOWN", "SPECIAL", "MOTO", "CAR", "CAROTHER", "BUS", "AXLECNT2", "AXLECNT3", "AXLECNT4", "AXLECNT4TRAILER", "AXLECNT5TRAILER", "AXLECNT6TRAILER", "AXLECNT5MULTITRAILER", "AXLECNT6MULTITRAILER", "AXLECNT7MULTITRAILER" ]
+    },
+    "SrmProperties" : {
+      "type" : "object",
+      "properties" : {
+        "asn1" : {
+          "type" : "string"
+        },
+        "elevation" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "heading" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "hpmsType" : {
+          "$ref" : "#/$defs/ProcessedVehicleType"
+        },
+        "importanceLevel" : {
+          "$ref" : "#/$defs/ProcessedRequestImportanceLevel"
+        },
+        "iso3833VehicleType" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "latitude" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "longitude" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "messageType" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "odeReceivedAt" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "originIp" : {
+          "type" : "string"
+        },
+        "requests" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/$defs/ProcessedSignalRequest"
+          }
+        },
+        "role" : {
+          "$ref" : "#/$defs/ProcessedBasicVehicleRole"
+        },
+        "routeName" : {
+          "type" : "string"
+        },
+        "schemaVersion" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "sequenceNumber" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "speedMetersPerSecond" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "subrole" : {
+          "$ref" : "#/$defs/ProcessedRequestSubRole"
+        },
+        "timeStamp" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "transitOccupancy" : {
+          "$ref" : "#/$defs/ProcessedTransitVehicleOccupancy"
+        },
+        "transitScheduleSeconds" : {
+          "$ref" : "#/$defs/Duration"
+        },
+        "transitStatus" : {
+          "$ref" : "#/$defs/ProcessedTransitVehicleStatus"
+        },
+        "transmission" : {
+          "$ref" : "#/$defs/ProcessedTransmissionState"
+        },
+        "validationMessages" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/$defs/ProcessedValidationMessage"
+          }
+        },
+        "vehicleID" : {
+          "type" : "string"
+        }
+      }
+    },
+    "Void" : {
+      "type" : "object"
+    }
+  },
+  "type" : "object",
+  "properties" : {
+    "geometry" : {
+      "$ref" : "#/$defs/Point-2"
+    },
+    "id" : {
+      "$ref" : "#/$defs/Void"
+    },
+    "properties" : {
+      "$ref" : "#/$defs/SrmProperties"
+    }
+  }
+}

--- a/jpo-geojsonconverter/src/main/resources/schemas/processed-ssm.schema.json
+++ b/jpo-geojsonconverter/src/main/resources/schemas/processed-ssm.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "$defs" : {
+    "Duration" : {
+      "type" : "object",
+      "properties" : {
+        "seconds" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      }
+    },
+    "ProcessedBasicVehicleRole" : {
+      "type" : "string",
+      "enum" : [ "BASICVEHICLE", "PUBLICTRANSPORT", "SPECIALTRANSPORT", "DANGEROUSGOODS", "ROADWORK", "ROADRESCUE", "EMERGENCY", "SAFETYCAR", "NONE_UNKNOWN", "TRUCK", "MOTORCYCLE", "ROADSIDESOURCE", "POLICE", "FIRE", "AMBULANCE", "DOT", "TRANSIT", "SLOWMOVING", "STOPNGO", "CYCLIST", "PEDESTRIAN", "NONMOTORIZED", "MILITARY" ]
+    },
+    "ProcessedPrioritizationResponseStatus" : {
+      "type" : "string",
+      "enum" : [ "UNKNOWN", "REQUESTED", "PROCESSING", "WATCHOTHERTRAFFIC", "GRANTED", "REJECTED", "MAXPRESENCE", "RESERVICELOCKED" ]
+    },
+    "ProcessedRequestImportanceLevel" : {
+      "type" : "string",
+      "enum" : [ "REQUESTIMPORTANCELEVELUNKNOWN", "REQUESTIMPORTANCELEVEL1", "REQUESTIMPORTANCELEVEL2", "REQUESTIMPORTANCELEVEL3", "REQUESTIMPORTANCELEVEL4", "REQUESTIMPORTANCELEVEL5", "REQUESTIMPORTANCELEVEL6", "REQUESTIMPORTANCELEVEL7", "REQUESTIMPORTANCELEVEL8", "REQUESTIMPORTANCELEVEL9", "REQUESTIMPORTANCELEVEL10", "REQUESTIMPORTANCELEVEL11", "REQUESTIMPORTANCELEVEL12", "REQUESTIMPORTANCELEVEL13", "REQUESTIMPORTANCELEVEL14", "REQUESTIMPORTANCERESERVED" ]
+    },
+    "ProcessedRequestSubRole" : {
+      "type" : "string",
+      "enum" : [ "REQUESTSUBROLEUNKNOWN", "REQUESTSUBROLE1", "REQUESTSUBROLE2", "REQUESTSUBROLE3", "REQUESTSUBROLE4", "REQUESTSUBROLE5", "REQUESTSUBROLE6", "REQUESTSUBROLE7", "REQUESTSUBROLE8", "REQUESTSUBROLE9", "REQUESTSUBROLE10", "REQUESTSUBROLE11", "REQUESTSUBROLE12", "REQUESTSUBROLE13", "REQUESTSUBROLE14", "REQUESTSUBROLERESERVED" ]
+    },
+    "ProcessedSignalStatus" : {
+      "type" : "object",
+      "properties" : {
+        "estimatedTimeOfArrival" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "estimatedTimeOfArrivalDurationSeconds" : {
+          "$ref" : "#/$defs/Duration"
+        },
+        "inboundOnApproachID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inboundOnLaneConnectionID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "inboundOnLaneID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "outboundOnApproachID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "outboundOnLaneConnectionID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "outboundOnLaneID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "requestID" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "requestImportanceLevel" : {
+          "$ref" : "#/$defs/ProcessedRequestImportanceLevel"
+        },
+        "requesterHpmsType" : {
+          "$ref" : "#/$defs/ProcessedVehicleType"
+        },
+        "requesterIso3833VehicleType" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "requesterRole" : {
+          "$ref" : "#/$defs/ProcessedBasicVehicleRole"
+        },
+        "requesterSequenceNumber" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "requesterSubrole" : {
+          "$ref" : "#/$defs/ProcessedRequestSubRole"
+        },
+        "status" : {
+          "$ref" : "#/$defs/ProcessedPrioritizationResponseStatus"
+        },
+        "vehicleID" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ProcessedValidationMessage" : {
+      "type" : "object",
+      "properties" : {
+        "exception" : {
+          "type" : "string"
+        },
+        "jsonPath" : {
+          "type" : "string"
+        },
+        "message" : {
+          "type" : "string"
+        },
+        "schemaPath" : {
+          "type" : "string"
+        }
+      }
+    },
+    "ProcessedVehicleType" : {
+      "type" : "string",
+      "enum" : [ "NONE", "UNKNOWN", "SPECIAL", "MOTO", "CAR", "CAROTHER", "BUS", "AXLECNT2", "AXLECNT3", "AXLECNT4", "AXLECNT4TRAILER", "AXLECNT5TRAILER", "AXLECNT6TRAILER", "AXLECNT5MULTITRAILER", "AXLECNT6MULTITRAILER", "AXLECNT7MULTITRAILER" ]
+    }
+  },
+  "type" : "object",
+  "properties" : {
+    "asn1" : {
+      "type" : "string"
+    },
+    "intersectionId" : {
+      "type" : "integer",
+      "format" : "int32"
+    },
+    "messageType" : {
+      "type" : "string"
+    },
+    "odeReceivedAt" : {
+      "type" : "string",
+      "format" : "date-time"
+    },
+    "originIp" : {
+      "type" : "string"
+    },
+    "region" : {
+      "type" : "integer",
+      "format" : "int32"
+    },
+    "schemaVersion" : {
+      "type" : "integer",
+      "format" : "int32"
+    },
+    "sequenceNumber" : {
+      "type" : "integer",
+      "format" : "int32"
+    },
+    "statusList" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/$defs/ProcessedSignalStatus"
+      }
+    },
+    "statusSequenceNumber" : {
+      "type" : "integer",
+      "format" : "int32"
+    },
+    "timeStamp" : {
+      "type" : "string",
+      "format" : "date-time"
+    },
+    "validationMessages" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/$defs/ProcessedValidationMessage"
+      }
+    }
+  }
+}

--- a/jpo-geojsonconverter/src/main/resources/schemas/srm.schema.json
+++ b/jpo-geojsonconverter/src/main/resources/schemas/srm.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "https://raw.githubusercontent.com/CDOT-CV/jpo-ode/refs/heads/dev/jpo-ode-core/src/main/resources/schemas/schema-srm.json"
+}

--- a/jpo-geojsonconverter/src/main/resources/schemas/ssm.schema.json
+++ b/jpo-geojsonconverter/src/main/resources/schemas/ssm.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "https://raw.githubusercontent.com/CDOT-CV/jpo-ode/refs/heads/dev/jpo-ode-core/src/main/resources/schemas/schema-ssm.json"
+}

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/TestResourceUtil.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/TestResourceUtil.java
@@ -1,0 +1,16 @@
+package us.dot.its.jpo.geojsonconverter;
+
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class TestResourceUtil {
+    public static String loadResource(String resourceName) throws IOException {
+        ResourceLoader resourceLoader = new DefaultResourceLoader();
+        Resource resource = resourceLoader.getResource(resourceName);
+        return resource.getContentAsString(StandardCharsets.UTF_8);
+    }
+}

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversionsTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversionsTest.java
@@ -9,7 +9,7 @@ import java.time.ZonedDateTime;
 
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 
 public class FieldConversionsTest {
     @Test
@@ -24,23 +24,46 @@ public class FieldConversionsTest {
         assertThat(year, equalTo(2025));
     }
 
+    @Test
+    public void testConvertMinuteOfYear_InvalidValue() {
+        ZonedDateTime ingestTime = ZonedDateTime.of(2025, 10, 3, 0, 0, 1, 500, ZoneOffset.UTC);
+        final var moy = new MinuteOfTheYear(527040L);
+        final ZonedDateTime minuteDate = FieldConversions.convertMinuteOfYear(moy, ingestTime);
+        assertThat(minuteDate, nullValue());
+    }
+
 
     @Test
     public void testConvertMinuteOfYear_YearEnd() {
         // Test edge case of message sent at the end of the year
-        final var moy = new MinuteOfTheYear(525600);  // Last minute of the year
+        final var moy = new MinuteOfTheYear(525599);  // Last minute of the year
 
         // Last minute of this year
         final ZonedDateTime ingestTimeThisYear = ZonedDateTime.of(2022, 12, 31, 23, 59, 59, 500, ZoneOffset.UTC);
         final ZonedDateTime minuteDate1 = FieldConversions.convertMinuteOfYear(moy, ingestTimeThisYear);
+        assertThat(minuteDate1, notNullValue());
         final int year1 = minuteDate1.getYear();
-        assertThat(year1, equalTo(moy));
         assertThat(year1, equalTo(2022));
 
         // First minute of next year
         final ZonedDateTime ingestTimeNextYear = ZonedDateTime.of(2023, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         final ZonedDateTime minuteDate2 = FieldConversions.convertMinuteOfYear(moy, ingestTimeNextYear);
+        assertThat(minuteDate2, notNullValue());
         final int year2 = minuteDate2.getYear();
         assertThat(year2, equalTo(2022));
+
+        final var moyLeap = new MinuteOfTheYear(527037L);
+        // Last minute of leap year
+        final ZonedDateTime ingestTimeThisLeapYear = ZonedDateTime.of(2024, 12, 31, 23, 59, 59, 500, ZoneOffset.UTC);
+        final ZonedDateTime minuteDateLeap1 = FieldConversions.convertMinuteOfYear(moyLeap, ingestTimeThisLeapYear);
+        assertThat(minuteDateLeap1, notNullValue());
+        final int yearLeap1 = minuteDateLeap1.getYear();
+        assertThat(yearLeap1, equalTo(2024));
+
+        final ZonedDateTime ingestTimeNextLeapYear = ZonedDateTime.of(2025, 1, 1, 0, 0, 1, 500, ZoneOffset.UTC);
+        final ZonedDateTime minuteDateLeap2 = FieldConversions.convertMinuteOfYear(moy, ingestTimeNextLeapYear);
+        assertThat(minuteDateLeap2, notNullValue());
+        final int yearLeap2 = minuteDateLeap2.getYear();
+        assertThat(yearLeap2, equalTo(2024));
     }
 }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversionsTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/FieldConversionsTest.java
@@ -1,0 +1,46 @@
+package us.dot.its.jpo.geojsonconverter.converter;
+
+import org.junit.Test;
+import us.dot.its.jpo.asn.j2735.r2024.Common.MinuteOfTheYear;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class FieldConversionsTest {
+    @Test
+    public void testConvertMinuteOfYear() {
+        // Normal case: middle of year
+        ZonedDateTime ingestTime = ZonedDateTime.of(2025, 10, 3, 0, 0, 1, 0, ZoneOffset.UTC);
+        final int dayOfYear = ingestTime.getDayOfYear();
+        final int minuteOfYear = dayOfYear * 24 * 60 + 5;
+        final var moy = new MinuteOfTheYear(minuteOfYear);
+        final ZonedDateTime minuteDate = FieldConversions.convertMinuteOfYear(moy, ingestTime);
+        final int year = minuteDate.getYear();
+        assertThat(year, equalTo(2025));
+    }
+
+
+    @Test
+    public void testConvertMinuteOfYear_YearEnd() {
+        // Test edge case of message sent at the end of the year
+        final var moy = new MinuteOfTheYear(525600);  // Last minute of the year
+
+        // Last minute of this year
+        final ZonedDateTime ingestTimeThisYear = ZonedDateTime.of(2022, 12, 31, 23, 59, 59, 500, ZoneOffset.UTC);
+        final ZonedDateTime minuteDate1 = FieldConversions.convertMinuteOfYear(moy, ingestTimeThisYear);
+        final int year1 = minuteDate1.getYear();
+        assertThat(year1, equalTo(moy));
+        assertThat(year1, equalTo(2022));
+
+        // First minute of next year
+        final ZonedDateTime ingestTimeNextYear = ZonedDateTime.of(2023, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        final ZonedDateTime minuteDate2 = FieldConversions.convertMinuteOfYear(moy, ingestTimeNextYear);
+        final int year2 = minuteDate2.getYear();
+        assertThat(year2, equalTo(2022));
+    }
+}

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/JsonConverterServiceControllerTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/JsonConverterServiceControllerTest.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import us.dot.its.jpo.geojsonconverter.GeoJsonConverterProperties;
 import us.dot.its.jpo.geojsonconverter.converter.rtcm.RTCMConverter;
+import us.dot.its.jpo.geojsonconverter.converter.srm.SrmConverter;
+import us.dot.its.jpo.geojsonconverter.converter.ssm.SsmConverter;
 import us.dot.its.jpo.geojsonconverter.validator.*;
 
 @SpringBootTest
@@ -39,6 +41,18 @@ public class JsonConverterServiceControllerTest {
     @Autowired
     RTCMConverter rtcmConverter;
 
+    @Autowired
+    SrmJsonValidator srmJsonValidator;
+
+    @Autowired
+    SrmConverter srmConverter;
+
+    @Autowired
+    SsmJsonValidator ssmJsonValidator;
+
+    @Autowired
+    SsmConverter ssmConverter;
+
     @Before
     public void setup() {
         props = new GeoJsonConverterProperties();
@@ -48,7 +62,8 @@ public class JsonConverterServiceControllerTest {
     @Test
     public void testSpringBootLoaded() {
         geoJsonConverterServiceController = new JsonConverterServiceController(props, mapJsonValidator,
-                spatJsonValidator, bsmJsonValidator, psmJsonValidator, rtcmJsonValidator, rtcmConverter);
+                spatJsonValidator, bsmJsonValidator, psmJsonValidator, rtcmJsonValidator, rtcmConverter,
+                srmJsonValidator, srmConverter, ssmJsonValidator, ssmConverter);
         assertNotNull(geoJsonConverterServiceController);
     }
 }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/rtcm/RTCMTopologyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/rtcm/RTCMTopologyTest.java
@@ -61,9 +61,7 @@ public class RTCMTopologyTest {
 
     @Test
     public void topologyTest() {
-        Resource jsonSchemaResource = getResource("schemas/rtcm.schema.json");
-        log.debug("jsonSchemaResource: {}", jsonSchemaResource);
-        RTCMJsonValidator validator = new RTCMJsonValidator(jsonSchemaResource);
+        RTCMJsonValidator validator = new RTCMJsonValidator("classpath:schemas/rtcm.schema.json");
         RTCMDecoder decoder = new RTCMDecoder(false);
         RTCMConverter converter = new RTCMConverter(decoder);
         Topology topology = RTCMTopology.build(inputTopicName, outputTopicName, validator, converter);

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/rtcm/RTCMTopologyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/rtcm/RTCMTopologyTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.*;
 @RunWith(Parameterized.class)
 public class RTCMTopologyTest {
 
-    final String inputTopicName = "topio.OdeRtcmJson";
+    final String inputTopicName = "topic.OdeRtcmJson";
     final String outputTopicName = "topic.ProcessedRtcm";
 
     @Parameter(0)

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverterTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverterTest.java
@@ -7,15 +7,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSignalRequest;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.runners.Parameterized.Parameters;
 import static org.junit.runners.Parameterized.Parameter;
 
@@ -36,15 +37,20 @@ public class SrmConverterTest {
         SrmConverter srmConverter = new SrmConverter();
         SignalRequestMessageMessageFrame messageFrame =
                 mapper.readValue(srmJson, SignalRequestMessageMessageFrame.class);
-        List<ProcessedSrm> processedSrm = srmConverter.processSrm(messageFrame);
+        ProcessedSrm processedSrm = srmConverter.processSrm(messageFrame);
         assertThat(processedSrm, notNullValue());
-        assertThat(processedSrm.size(), equalTo(expectNumberOfRequests));
+        SrmProperties props = processedSrm.getProperties();
+        assertThat(props, hasProperty("requests", notNullValue()));
+        List<ProcessedSignalRequest> requests = props.getRequests();
+        assertThat(requests, hasSize(expectNumberOfRequests));
     }
 
     @Parameters
     public static Collection<Object[]> params() {
         return Arrays.asList(new Object[][] {
-                { SRM, 1 }
+                { SRM, 1 },
+                { SRM_2LANES, 2},
+                { SRM_4LANES, 4}
         });
     }
 
@@ -91,6 +97,172 @@ public class SrmConverterTest {
                       "speed": {
                         "transmisson": "unavailable",
                         "speed": 512
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+    public static final String SRM_2LANES = """
+            {
+              "messageId": 29,
+              "value": {
+                "SignalRequestMessage": {
+                  "timeStamp": 374789,
+                  "second": 0,
+                  "sequenceNumber": 8,
+                  "requests": [
+                    {
+                      "request": {
+                        "id": {
+                          "id": 12114
+                        },
+                        "requestID": 5,
+                        "requestType": "priorityRequest",
+                        "inBoundLane": {
+                          "lane": 1
+                        },
+                        "outBoundLane": {
+                          "lane": 16
+                        }
+                      },
+                      "duration": 34325
+                    },
+                    {
+                      "request": {
+                        "id": {
+                          "id": 12114
+                        },
+                        "requestID": 4,
+                        "requestType": "priorityCancellation",
+                        "inBoundLane": {
+                          "lane": 2
+                        },
+                        "outBoundLane": {
+                          "lane": 15
+                        }
+                      },
+                      "duration": 36145
+                    }
+                  ],
+                  "requestor": {
+                    "id": {
+                      "stationID": 2031825062
+                    },
+                    "type": {
+                      "role": "publicTransport"
+                    },
+                    "position": {
+                      "position": {
+                        "lat": 395533186,
+                        "long": -1050850893,
+                        "elevation": 16791
+                      },
+                      "heading": 1312,
+                      "speed": {
+                        "transmisson": "unavailable",
+                        "speed": 418
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+    public static final String SRM_4LANES = """
+            {
+              "messageId": 29,
+              "value": {
+                "SignalRequestMessage": {
+                  "timeStamp": 374532,
+                  "second": 0,
+                  "sequenceNumber": 9,
+                  "requests": [
+                    {
+                      "request": {
+                        "id": {
+                          "id": 8802
+                        },
+                        "requestID": 4,
+                        "requestType": "priorityCancellation",
+                        "inBoundLane": {
+                          "lane": 28
+                        },
+                        "outBoundLane": {
+                          "lane": 26
+                        }
+                      },
+                      "duration": 5624
+                    },
+                    {
+                      "request": {
+                        "id": {
+                          "id": 8802
+                        },
+                        "requestID": 3,
+                        "requestType": "priorityCancellation",
+                        "inBoundLane": {
+                          "lane": 1
+                        },
+                        "outBoundLane": {
+                          "lane": 19
+                        }
+                      },
+                      "duration": 6078
+                    },
+                    {
+                      "request": {
+                        "id": {
+                          "id": 8802
+                        },
+                        "requestID": 1,
+                        "requestType": "priorityCancellation",
+                        "inBoundLane": {
+                          "lane": 3
+                        },
+                        "outBoundLane": {
+                          "lane": 17
+                        }
+                      },
+                      "duration": 6173
+                    },
+                    {
+                      "request": {
+                        "id": {
+                          "id": 8802
+                        },
+                        "requestID": 2,
+                        "requestType": "priorityCancellation",
+                        "inBoundLane": {
+                          "lane": 2
+                        },
+                        "outBoundLane": {
+                          "lane": 18
+                        }
+                      },
+                      "duration": 6101
+                    }
+                  ],
+                  "requestor": {
+                    "id": {
+                      "stationID": 312977750
+                    },
+                    "type": {
+                      "role": "publicTransport"
+                    },
+                    "position": {
+                      "position": {
+                        "lat": 395939481,
+                        "long": -1048844050,
+                        "elevation": 17525
+                      },
+                      "heading": 12568,
+                      "speed": {
+                        "transmisson": "unavailable",
+                        "speed": 1417
                       }
                     }
                   }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverterTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverterTest.java
@@ -1,0 +1,101 @@
+package us.dot.its.jpo.geojsonconverter.converter.srm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.runners.Parameterized.Parameters;
+import static org.junit.runners.Parameterized.Parameter;
+
+@Slf4j
+@RunWith(Parameterized.class)
+public class SrmConverterTest {
+
+    private final static ObjectMapper mapper = new ObjectMapper();
+
+    @Parameter(0)
+    public String srmJson;
+
+    @Parameter(1)
+    public int expectNumberOfRequests;
+
+    @Test
+    public void testProcessSrm() throws JsonProcessingException {
+        SrmConverter srmConverter = new SrmConverter();
+        SignalRequestMessageMessageFrame messageFrame =
+                mapper.readValue(srmJson, SignalRequestMessageMessageFrame.class);
+        List<ProcessedSrm> processedSrm = srmConverter.processSrm(messageFrame);
+        assertThat(processedSrm, notNullValue());
+        assertThat(processedSrm.size(), equalTo(expectNumberOfRequests));
+    }
+
+    @Parameters
+    public static Collection<Object[]> params() {
+        return Arrays.asList(new Object[][] {
+                { SRM, 1 }
+        });
+    }
+
+    public static final String SRM = """
+            {
+              "messageId": 29,
+              "value": {
+                "SignalRequestMessage": {
+                  "timeStamp": 374789,
+                  "second": 0,
+                  "sequenceNumber": 11,
+                  "requests": [
+                    {
+                      "request": {
+                        "id": {
+                          "id": 12114
+                        },
+                        "requestID": 5,
+                        "requestType": "priorityRequest",
+                        "inBoundLane": {
+                          "lane": 1
+                        },
+                        "outBoundLane": {
+                          "lane": 16
+                        }
+                      },
+                      "duration": 34325
+                    }
+                  ],
+                  "requestor": {
+                    "id": {
+                      "stationID": 2031825062
+                    },
+                    "type": {
+                      "role": "publicTransport"
+                    },
+                    "position": {
+                      "position": {
+                        "lat": 395534788,
+                        "long": -1050850214,
+                        "elevation": 16788
+                      },
+                      "heading": 1496,
+                      "speed": {
+                        "transmisson": "unavailable",
+                        "speed": 512
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+}

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverterTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverterTest.java
@@ -6,11 +6,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSignalRequest;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -19,6 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.runners.Parameterized.Parameters;
 import static org.junit.runners.Parameterized.Parameter;
+import static us.dot.its.jpo.geojsonconverter.TestResourceUtil.loadResource;
 
 @Slf4j
 @RunWith(Parameterized.class)
@@ -46,228 +52,16 @@ public class SrmConverterTest {
     }
 
     @Parameters
-    public static Collection<Object[]> params() {
+    public static Collection<Object[]> params() throws IOException {
+        final String srm1Lane = loadResource("classpath:json/srm.message-frame.json");
+        final String srm2Lanes = loadResource("classpath:json/srm.message-frame.2lanes.json");
+        final String srm4Lanes = loadResource("classpath:json/srm.message-frame.4lanes.json");
         return Arrays.asList(new Object[][] {
-                { SRM, 1 },
-                { SRM_2LANES, 2},
-                { SRM_4LANES, 4}
+                { srm1Lane, 1 },
+                { srm2Lanes, 2},
+                { srm4Lanes, 4}
         });
     }
 
-    public static final String SRM = """
-            {
-              "messageId": 29,
-              "value": {
-                "SignalRequestMessage": {
-                  "timeStamp": 374789,
-                  "second": 0,
-                  "sequenceNumber": 11,
-                  "requests": [
-                    {
-                      "request": {
-                        "id": {
-                          "id": 12114
-                        },
-                        "requestID": 5,
-                        "requestType": "priorityRequest",
-                        "inBoundLane": {
-                          "lane": 1
-                        },
-                        "outBoundLane": {
-                          "lane": 16
-                        }
-                      },
-                      "duration": 34325
-                    }
-                  ],
-                  "requestor": {
-                    "id": {
-                      "stationID": 2031825062
-                    },
-                    "type": {
-                      "role": "publicTransport"
-                    },
-                    "position": {
-                      "position": {
-                        "lat": 395534788,
-                        "long": -1050850214,
-                        "elevation": 16788
-                      },
-                      "heading": 1496,
-                      "speed": {
-                        "transmisson": "unavailable",
-                        "speed": 512
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            """;
 
-    public static final String SRM_2LANES = """
-            {
-              "messageId": 29,
-              "value": {
-                "SignalRequestMessage": {
-                  "timeStamp": 374789,
-                  "second": 0,
-                  "sequenceNumber": 8,
-                  "requests": [
-                    {
-                      "request": {
-                        "id": {
-                          "id": 12114
-                        },
-                        "requestID": 5,
-                        "requestType": "priorityRequest",
-                        "inBoundLane": {
-                          "lane": 1
-                        },
-                        "outBoundLane": {
-                          "lane": 16
-                        }
-                      },
-                      "duration": 34325
-                    },
-                    {
-                      "request": {
-                        "id": {
-                          "id": 12114
-                        },
-                        "requestID": 4,
-                        "requestType": "priorityCancellation",
-                        "inBoundLane": {
-                          "lane": 2
-                        },
-                        "outBoundLane": {
-                          "lane": 15
-                        }
-                      },
-                      "duration": 36145
-                    }
-                  ],
-                  "requestor": {
-                    "id": {
-                      "stationID": 2031825062
-                    },
-                    "type": {
-                      "role": "publicTransport"
-                    },
-                    "position": {
-                      "position": {
-                        "lat": 395533186,
-                        "long": -1050850893,
-                        "elevation": 16791
-                      },
-                      "heading": 1312,
-                      "speed": {
-                        "transmisson": "unavailable",
-                        "speed": 418
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            """;
-
-    public static final String SRM_4LANES = """
-            {
-              "messageId": 29,
-              "value": {
-                "SignalRequestMessage": {
-                  "timeStamp": 374532,
-                  "second": 0,
-                  "sequenceNumber": 9,
-                  "requests": [
-                    {
-                      "request": {
-                        "id": {
-                          "id": 8802
-                        },
-                        "requestID": 4,
-                        "requestType": "priorityCancellation",
-                        "inBoundLane": {
-                          "lane": 28
-                        },
-                        "outBoundLane": {
-                          "lane": 26
-                        }
-                      },
-                      "duration": 5624
-                    },
-                    {
-                      "request": {
-                        "id": {
-                          "id": 8802
-                        },
-                        "requestID": 3,
-                        "requestType": "priorityCancellation",
-                        "inBoundLane": {
-                          "lane": 1
-                        },
-                        "outBoundLane": {
-                          "lane": 19
-                        }
-                      },
-                      "duration": 6078
-                    },
-                    {
-                      "request": {
-                        "id": {
-                          "id": 8802
-                        },
-                        "requestID": 1,
-                        "requestType": "priorityCancellation",
-                        "inBoundLane": {
-                          "lane": 3
-                        },
-                        "outBoundLane": {
-                          "lane": 17
-                        }
-                      },
-                      "duration": 6173
-                    },
-                    {
-                      "request": {
-                        "id": {
-                          "id": 8802
-                        },
-                        "requestID": 2,
-                        "requestType": "priorityCancellation",
-                        "inBoundLane": {
-                          "lane": 2
-                        },
-                        "outBoundLane": {
-                          "lane": 18
-                        }
-                      },
-                      "duration": 6101
-                    }
-                  ],
-                  "requestor": {
-                    "id": {
-                      "stationID": 312977750
-                    },
-                    "type": {
-                      "role": "publicTransport"
-                    },
-                    "position": {
-                      "position": {
-                        "lat": 395939481,
-                        "long": -1048844050,
-                        "elevation": 17525
-                      },
-                      "heading": 12568,
-                      "speed": {
-                        "transmisson": "unavailable",
-                        "speed": 1417
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            """;
 }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopologyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopologyTest.java
@@ -1,0 +1,4 @@
+package us.dot.its.jpo.geojsonconverter.converter.srm;
+
+public class SrmTopologyTest {
+}

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopologyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopologyTest.java
@@ -1,4 +1,99 @@
 package us.dot.its.jpo.geojsonconverter.converter.srm;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.serialization.VoidSerializer;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import us.dot.its.jpo.geojsonconverter.partitioner.RsuVehicleIdKey;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
+import us.dot.its.jpo.geojsonconverter.serialization.deserializers.JsonDeserializer;
+import us.dot.its.jpo.geojsonconverter.validator.SrmJsonValidator;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+
+@Slf4j
+@RunWith(Parameterized.class)
 public class SrmTopologyTest {
+    final String inputTopicName = "topic.OdeSrmJson";
+    final String outputTopicName = "topic.ProcessedSrm";
+
+    @Parameter(0)
+    public String inputJson;
+
+    @Parameters
+    public static Collection<Object[]> params() throws IOException {
+        return Arrays.asList(new Object[][] {
+                { loadResource("json/valid.srm.json") }
+        });
+    }
+
+    @Test
+    public void topologyTest() {
+        Resource jsonSchemaResource = getResource("schemas/srm.schema.json");
+        SrmJsonValidator validator = new SrmJsonValidator(jsonSchemaResource);
+        SrmConverter converter = new SrmConverter();
+        Topology topology = SrmTopology.build(inputTopicName, outputTopicName, validator, converter);
+        try (var driver = new TopologyTestDriver(topology)) {
+            var inputTopic = driver.createInputTopic(inputTopicName, new VoidSerializer(), new StringSerializer());
+            var outputTopic = driver.createOutputTopic(outputTopicName,
+                    new JsonDeserializer<>(RsuVehicleIdKey.class), new JsonDeserializer<>(ProcessedSrm.class));
+
+            inputTopic.pipeInput(inputJson);
+
+            List<KeyValue<RsuVehicleIdKey, ProcessedSrm>> results = outputTopic.readKeyValuesToList();
+
+            assertThat(results, hasSize(1));
+
+            KeyValue<RsuVehicleIdKey, ProcessedSrm> result = results.getFirst();
+            RsuVehicleIdKey key = result.key;
+            assertThat(key, notNullValue());
+            assertThat(key.getRsuId(), equalTo("172.18.0.1"));
+            ProcessedSrm processedSrm = result.value;
+            assertThat(processedSrm, notNullValue());
+            SrmProperties properties = processedSrm.getProperties();
+            assertThat(properties, notNullValue());
+            assertThat(properties.getAsn1(), notNullValue());
+            assertThat(properties.getOdeReceivedAt(), notNullValue());
+            assertThat(properties.getMessageType(), equalTo("SRM"));
+            assertThat(properties.getRequests(), hasSize(greaterThan(0)));
+
+            Point geometry = processedSrm.getGeometry();
+            assertThat(geometry, notNullValue());
+        }
+    }
+
+    private static String loadResource(String path) throws IOException {
+        Resource resource = getResource(path);
+        return readResource(resource);
+    }
+
+    private static Resource getResource(String path) {
+        ResourceLoader resourceLoader = new DefaultResourceLoader();
+        return resourceLoader.getResource("classpath:" + path);
+    }
+
+    private static String readResource(Resource resource) throws IOException {
+        byte[] bytes = resource.getInputStream().readAllBytes();
+        return  new String(bytes, StandardCharsets.UTF_8);
+    }
 }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopologyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopologyTest.java
@@ -57,8 +57,7 @@ public class SrmTopologyTest {
 
     @Test
     public void topologyTest() {
-        Resource jsonSchemaResource = getResource("schemas/srm.schema.json");
-        SrmJsonValidator validator = new SrmJsonValidator(jsonSchemaResource);
+        SrmJsonValidator validator = new SrmJsonValidator("classpath:schemas/srm.schema.json");
         SrmConverter converter = new SrmConverter();
         Topology topology = SrmTopology.build(inputTopicName, outputTopicName, validator, converter);
         try (var driver = new TopologyTestDriver(topology)) {

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopologyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmTopologyTest.java
@@ -40,10 +40,18 @@ public class SrmTopologyTest {
     @Parameter(0)
     public String inputJson;
 
+    @Parameter(1)
+    public int expectNumberOfRequests;
+
+    @Parameter(2)
+    public boolean expectValid;
+
     @Parameters
     public static Collection<Object[]> params() throws IOException {
         return Arrays.asList(new Object[][] {
-                { loadResource("json/valid.srm.json") }
+                { loadResource("json/valid.srm.json"), 1, true },
+                { loadResource("json/valid.srm-multi.json"), 2, true },
+                { loadResource("json/invalid.srm.json"), 1, false}
         });
     }
 
@@ -75,7 +83,15 @@ public class SrmTopologyTest {
             assertThat(properties.getAsn1(), notNullValue());
             assertThat(properties.getOdeReceivedAt(), notNullValue());
             assertThat(properties.getMessageType(), equalTo("SRM"));
-            assertThat(properties.getRequests(), hasSize(greaterThan(0)));
+            assertThat(properties.getRequests(), hasSize(equalTo(expectNumberOfRequests)));
+            if (expectValid) {
+                assertThat("expected valid message but has validation messages",
+                        properties.getValidationMessages(), hasSize(equalTo(0)));
+            } else {
+                assertThat("expected invalid message but has no validation messages",
+                        properties.getValidationMessages(), hasSize(greaterThan(0)));
+            }
+
 
             Point geometry = processedSrm.getGeometry();
             assertThat(geometry, notNullValue());

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverterTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverterTest.java
@@ -1,0 +1,91 @@
+package us.dot.its.jpo.geojsonconverter.converter.ssm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.runners.Parameterized.Parameters;
+import static org.junit.runners.Parameterized.Parameter;
+
+@Slf4j
+@RunWith(Parameterized.class)
+public class SsmConverterTest {
+
+    private final static ObjectMapper mapper = new ObjectMapper();
+
+    @Parameter(0)
+    public String ssmJson;
+
+    @Parameter(1)
+    public int expectNumberOfRequests;
+
+    @Test
+    public void testProcessSsm() throws JsonProcessingException {
+        SsmConverter ssmConverter = new SsmConverter();
+        SignalStatusMessageMessageFrame messageFrame =
+                mapper.readValue(ssmJson, SignalStatusMessageMessageFrame.class);
+        List<ProcessedSsm> processedSsm = ssmConverter.processSsm(messageFrame);
+        assertThat(processedSsm, notNullValue());
+        assertThat(processedSsm.size(), equalTo(expectNumberOfRequests));
+    }
+
+    @Parameters
+    public static Collection<Object[]> params() {
+        return Arrays.asList(new Object[][] {
+                { SSM, 1}
+        });
+    }
+
+    public static final String SSM = """
+            {
+              "messageId": 30,
+              "value": {
+                "SignalStatusMessage": {
+                  "timeStamp": 374789,
+                  "second": 31000,
+                  "sequenceNumber": 15,
+                  "status": [
+                    {
+                      "sequenceNumber": 30,
+                      "id": {
+                        "id": 12114
+                      },
+                      "sigStatus": [
+                        {
+                          "requester": {
+                            "id": {
+                              "stationID": 2031825062
+                            },
+                            "request": 5,
+                            "sequenceNumber": 5,
+                            "role": "publicTransport"
+                          },
+                          "inboundOn": {
+                            "lane": 1
+                          },
+                          "outboundOn": {
+                            "lane": 16
+                          },
+                          "duration": 34325,
+                          "status": "granted"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+            """;
+}

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverterTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverterTest.java
@@ -14,8 +14,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.runners.Parameterized.Parameters;
 import static org.junit.runners.Parameterized.Parameter;
 
@@ -36,9 +35,10 @@ public class SsmConverterTest {
         SsmConverter ssmConverter = new SsmConverter();
         SignalStatusMessageMessageFrame messageFrame =
                 mapper.readValue(ssmJson, SignalStatusMessageMessageFrame.class);
-        List<ProcessedSsm> processedSsm = ssmConverter.processSsm(messageFrame);
+        ProcessedSsm processedSsm = ssmConverter.processSsm(messageFrame);
         assertThat(processedSsm, notNullValue());
-        assertThat(processedSsm.size(), equalTo(expectNumberOfRequests));
+        assertThat(processedSsm, hasProperty("statusList", notNullValue()));
+        assertThat(processedSsm.getStatusList(), hasSize(equalTo(expectNumberOfRequests)));
     }
 
     @Parameters

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverterTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverterTest.java
@@ -11,7 +11,6 @@ import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverterTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmConverterTest.java
@@ -6,9 +6,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame;
 import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -16,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.runners.Parameterized.Parameters;
 import static org.junit.runners.Parameterized.Parameter;
+import static us.dot.its.jpo.geojsonconverter.TestResourceUtil.loadResource;
 
 @Slf4j
 @RunWith(Parameterized.class)
@@ -41,50 +49,14 @@ public class SsmConverterTest {
     }
 
     @Parameters
-    public static Collection<Object[]> params() {
+    public static Collection<Object[]> params() throws IOException {
+        final String ssmJson = loadResource("classpath:json/ssm.message-frame.json");
+        final String ssmJsonMulti = loadResource("classpath:json/ssm.message-frame.multi.json");
         return Arrays.asList(new Object[][] {
-                { SSM, 1}
+                { ssmJson, 1},
+                { ssmJsonMulti, 2}
         });
     }
 
-    public static final String SSM = """
-            {
-              "messageId": 30,
-              "value": {
-                "SignalStatusMessage": {
-                  "timeStamp": 374789,
-                  "second": 31000,
-                  "sequenceNumber": 15,
-                  "status": [
-                    {
-                      "sequenceNumber": 30,
-                      "id": {
-                        "id": 12114
-                      },
-                      "sigStatus": [
-                        {
-                          "requester": {
-                            "id": {
-                              "stationID": 2031825062
-                            },
-                            "request": 5,
-                            "sequenceNumber": 5,
-                            "role": "publicTransport"
-                          },
-                          "inboundOn": {
-                            "lane": 1
-                          },
-                          "outboundOn": {
-                            "lane": 16
-                          },
-                          "duration": 34325,
-                          "status": "granted"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            }
-            """;
+
 }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopologyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopologyTest.java
@@ -43,10 +43,18 @@ public class SsmTopologyTest {
     @Parameter(0)
     public String inputJson;
 
+    @Parameter(1)
+    public int expectNumberOfRequests;
+
+    @Parameter(2)
+    public boolean expectValid;
+
     @Parameters
     public static Collection<Object[]> params() throws IOException {
         return Arrays.asList(new Object[][] {
-                { loadResource("json/valid.ssm.json") }
+                { loadResource("json/valid.ssm.json"), 1, true },
+                { loadResource("json/valid.ssm-multi.json"), 2, true },
+                { loadResource("json/invalid.ssm.json"), 1, false },
         });
     }
 
@@ -77,6 +85,13 @@ public class SsmTopologyTest {
             assertThat(processedSsm.getOdeReceivedAt(), notNullValue());
             assertThat(processedSsm.getMessageType(), equalTo("SSM"));
             assertThat(processedSsm.getStatusList(), hasSize(greaterThan(0)));
+            if (expectValid) {
+                assertThat("expected valid message but has validation messages",
+                        processedSsm.getValidationMessages(), hasSize(equalTo(0)));
+            } else {
+                assertThat("expected invalid message but has no validation messages",
+                        processedSsm.getValidationMessages(), hasSize(greaterThan(0)));
+            }
         }
     }
 

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopologyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopologyTest.java
@@ -1,4 +1,97 @@
 package us.dot.its.jpo.geojsonconverter.converter.ssm;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.serialization.VoidSerializer;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import us.dot.its.jpo.geojsonconverter.converter.srm.SrmConverter;
+import us.dot.its.jpo.geojsonconverter.converter.srm.SrmTopology;
+import us.dot.its.jpo.geojsonconverter.partitioner.RsuVehicleIdKey;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
+import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+import us.dot.its.jpo.geojsonconverter.serialization.deserializers.JsonDeserializer;
+import us.dot.its.jpo.geojsonconverter.validator.SrmJsonValidator;
+import us.dot.its.jpo.geojsonconverter.validator.SsmJsonValidator;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@Slf4j
+@RunWith(Parameterized.class)
 public class SsmTopologyTest {
+    final String inputTopicName = "topic.OdeSsmJson";
+    final String outputTopicName = "topic.ProcessedSsm";
+
+    @Parameter(0)
+    public String inputJson;
+
+    @Parameters
+    public static Collection<Object[]> params() throws IOException {
+        return Arrays.asList(new Object[][] {
+                { loadResource("json/valid.ssm.json") }
+        });
+    }
+
+    @Test
+    public void topologyTest() {
+        Resource jsonSchemaResource = getResource("schemas/ssm.schema.json");
+        SsmJsonValidator validator = new SsmJsonValidator(jsonSchemaResource);
+        SsmConverter converter = new SsmConverter();
+        Topology topology = SsmTopology.build(inputTopicName, outputTopicName, validator, converter);
+        try (var driver = new TopologyTestDriver(topology)) {
+            var inputTopic = driver.createInputTopic(inputTopicName, new VoidSerializer(), new StringSerializer());
+            var outputTopic = driver.createOutputTopic(outputTopicName,
+                    new JsonDeserializer<>(RsuVehicleIdKey.class), new JsonDeserializer<>(ProcessedSsm.class));
+
+            inputTopic.pipeInput(inputJson);
+
+            List<KeyValue<RsuVehicleIdKey, ProcessedSsm>> results = outputTopic.readKeyValuesToList();
+
+            assertThat(results, hasSize(1));
+
+            KeyValue<RsuVehicleIdKey, ProcessedSsm> result = results.getFirst();
+            RsuVehicleIdKey key = result.key;
+            assertThat(key, notNullValue());
+            assertThat(key.getRsuId(), equalTo("172.18.0.1"));
+            ProcessedSsm processedSsm = result.value;
+            assertThat(processedSsm, notNullValue());
+            assertThat(processedSsm.getAsn1(), notNullValue());
+            assertThat(processedSsm.getOdeReceivedAt(), notNullValue());
+            assertThat(processedSsm.getMessageType(), equalTo("SSM"));
+            assertThat(processedSsm.getStatusList(), hasSize(greaterThan(0)));
+        }
+    }
+
+    private static String loadResource(String path) throws IOException {
+        Resource resource = getResource(path);
+        return readResource(resource);
+    }
+
+    private static Resource getResource(String path) {
+        ResourceLoader resourceLoader = new DefaultResourceLoader();
+        return resourceLoader.getResource("classpath:" + path);
+    }
+
+    private static String readResource(Resource resource) throws IOException {
+        byte[] bytes = resource.getInputStream().readAllBytes();
+        return  new String(bytes, StandardCharsets.UTF_8);
+    }
 }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopologyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopologyTest.java
@@ -14,15 +14,9 @@ import org.junit.runners.Parameterized.Parameters;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
-import us.dot.its.jpo.geojsonconverter.converter.srm.SrmConverter;
-import us.dot.its.jpo.geojsonconverter.converter.srm.SrmTopology;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuVehicleIdKey;
-import us.dot.its.jpo.geojsonconverter.pojos.geojson.Point;
-import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
-import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
 import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
 import us.dot.its.jpo.geojsonconverter.serialization.deserializers.JsonDeserializer;
-import us.dot.its.jpo.geojsonconverter.validator.SrmJsonValidator;
 import us.dot.its.jpo.geojsonconverter.validator.SsmJsonValidator;
 
 import java.io.IOException;

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopologyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopologyTest.java
@@ -54,8 +54,7 @@ public class SsmTopologyTest {
 
     @Test
     public void topologyTest() {
-        Resource jsonSchemaResource = getResource("schemas/ssm.schema.json");
-        SsmJsonValidator validator = new SsmJsonValidator(jsonSchemaResource);
+        SsmJsonValidator validator = new SsmJsonValidator("classpath:schemas/ssm.schema.json");
         SsmConverter converter = new SsmConverter();
         Topology topology = SsmTopology.build(inputTopicName, outputTopicName, validator, converter);
         try (var driver = new TopologyTestDriver(topology)) {

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopologyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmTopologyTest.java
@@ -1,0 +1,4 @@
+package us.dot.its.jpo.geojsonconverter.converter.ssm;
+
+public class SsmTopologyTest {
+}

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/validator/SrmJsonValidatorTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/validator/SrmJsonValidatorTest.java
@@ -1,0 +1,76 @@
+package us.dot.its.jpo.geojsonconverter.validator;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+
+@SpringBootTest({
+        "valid.srm.json=classpath:json/valid.srm.json",
+        "invalid.srm.json=classpath:json/invalid.srm.json"})
+@RunWith(SpringRunner.class)
+@ActiveProfiles("test")
+public class SrmJsonValidatorTest extends AbstractJsonValidatorTest {
+
+    @Autowired
+    private SrmJsonValidator jsonValidator;
+
+    @Test
+    public void jsonValidatorLoaded() {
+        assertThat(jsonValidator, notNullValue());
+    }
+
+    @Test
+    public void jsonSchemaResourceLoaded() {
+        testJsonSchemaResourceLoaded(jsonValidator);
+    }
+
+    @Test
+    public void jsonSchemaLoaded() throws IOException {
+        testJsonSchemaLoaded(jsonValidator);
+    }
+
+    @Test
+    public void validJsonTest_String() {
+        testJson(jsonValidator, validJsonResource, true);
+    }
+
+    @Test
+    public void invalidJsonTest_String() {
+        testJson(jsonValidator, invalidJsonResource, false);
+    }
+
+    @Test
+    public void validJsonTest_ByteArray() {
+        testJson_ByteArray(jsonValidator, validJsonResource, true);
+    }
+
+    @Test
+    public void invalidJsonTest_ByteArray() {
+        testJson_ByteArray(jsonValidator, invalidJsonResource, false);
+    }
+
+    @Test
+    public void testException() {
+        SrmJsonValidator badValidator = new SrmJsonValidator(null);
+        var result = badValidator.validate("invalid");
+        assertFalse("An exception should have happened", result.isValid());
+    }
+
+
+    @Value("${valid.srm.json}")
+    private Resource validJsonResource;
+
+    @Value("${invalid.srm.json}")
+    private Resource invalidJsonResource;
+}

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidatorTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidatorTest.java
@@ -62,7 +62,7 @@ public class SsmJsonValidatorTest extends AbstractJsonValidatorTest {
 
     @Test
     public void testException() {
-        SrmJsonValidator badValidator = new SrmJsonValidator(null);
+        SsmJsonValidator badValidator = new SsmJsonValidator(null);
         var result = badValidator.validate("invalid");
         assertFalse("An exception should have happened", result.isValid());
     }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidatorTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/validator/SsmJsonValidatorTest.java
@@ -1,0 +1,75 @@
+package us.dot.its.jpo.geojsonconverter.validator;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+
+@SpringBootTest({
+        "valid.ssm.json=classpath:json/valid.ssm.json",
+        "invalid.ssm.json=classpath:json/invalid.ssm.json"})
+@RunWith(SpringRunner.class)
+@ActiveProfiles("test")
+public class SsmJsonValidatorTest extends AbstractJsonValidatorTest {
+
+    @Autowired
+    private SsmJsonValidator jsonValidator;
+
+    @Test
+    public void jsonValidatorLoaded() {
+        assertThat(jsonValidator, notNullValue());
+    }
+
+    @Test
+    public void jsonSchemaResourceLoaded() {
+        testJsonSchemaResourceLoaded(jsonValidator);
+    }
+
+    @Test
+    public void jsonSchemaLoaded() throws IOException {
+        testJsonSchemaLoaded(jsonValidator);
+    }
+
+    @Test
+    public void validJsonTest_String() {
+        testJson(jsonValidator, validJsonResource, true);
+    }
+
+    @Test
+    public void invalidJsonTest_String() {
+        testJson(jsonValidator, invalidJsonResource, false);
+    }
+
+    @Test
+    public void validJsonTest_ByteArray() {
+        testJson_ByteArray(jsonValidator, validJsonResource, true);
+    }
+
+    @Test
+    public void invalidJsonTest_ByteArray() {
+        testJson_ByteArray(jsonValidator, invalidJsonResource, false);
+    }
+
+    @Test
+    public void testException() {
+        SrmJsonValidator badValidator = new SrmJsonValidator(null);
+        var result = badValidator.validate("invalid");
+        assertFalse("An exception should have happened", result.isValid());
+    }
+
+    @Value("${valid.ssm.json}")
+    private Resource validJsonResource;
+
+    @Value("${invalid.ssm.json}")
+    private Resource invalidJsonResource;
+}

--- a/jpo-geojsonconverter/src/test/resources/json/invalid.srm.json
+++ b/jpo-geojsonconverter/src/test/resources/json/invalid.srm.json
@@ -1,0 +1,77 @@
+{
+  "metadata": {
+    "logFileName": "",
+    "recordType": "srmTx",
+    "securityResultCode": "success",
+    "receivedMessageDetails": {
+      "rxSource": "NA"
+    },
+    "payloadType": "us.dot.its.jpo.ode.model.OdeMessageFramePayload",
+    "serialId": {
+      "streamId": "b18d90c6-448a-4019-b259-12232676c718",
+      "bundleSize": 1,
+      "bundleId": 0,
+      "recordId": 0,
+      "serialNumber": 0
+    },
+    "odeReceivedAt": "2025-09-25T17:26:11.873Z",
+    "schemaVersion": 9,
+    "maxDurationTime": 0,
+    "recordGeneratedAt": "",
+    "recordGeneratedBy": "OBU",
+    "sanitized": false,
+    "odePacketID": "",
+    "odeTimStartDateTime": "",
+    "asn1": "001D2672DC0280000B0090BD48148010210C2AC0BC8D9853000B534E12B10B29C796546502EC710000",
+    "source": "RSU",
+    "originIp": "172.18.0.1",
+    "isCertPresent": false
+  },
+  "payload": {
+    "data": {
+      "messageId": 29,
+      "value": {
+        "SignalRequestMessage": {
+          "timeStamp": 374789,
+          "sequenceNumber": 11,
+          "requests": [
+            {
+              "request": {
+                "id": {
+                  "id": 12114
+                },
+                "requestID": 5,
+                "requestType": "priorityRequest",
+                "inBoundLane": {
+                  "lane": 1
+                },
+                "outBoundLane": {
+                  "lane": 16
+                }
+              },
+              "duration": 34325
+            }
+          ],
+          "requestor": {
+            "type": {
+              "role": "publicTransport"
+            },
+            "position": {
+              "position": {
+                "lat": 395534788,
+                "long": -1050850214,
+                "elevation": 16788
+              },
+              "heading": 1496,
+              "speed": {
+                "transmisson": "unavailable",
+                "speed": 512
+              }
+            }
+          }
+        }
+      }
+    },
+    "dataType": "us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame"
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/invalid.ssm.json
+++ b/jpo-geojsonconverter/src/test/resources/json/invalid.ssm.json
@@ -1,0 +1,67 @@
+{
+  "metadata": {
+    "logFileName": "",
+    "recordType": "ssmTx",
+    "securityResultCode": "success",
+    "receivedMessageDetails": {
+      "rxSource": "NA"
+    },
+    "payloadType": "us.dot.its.jpo.ode.model.OdeMessageFramePayload",
+    "serialId": {
+      "streamId": "64c77df2-e59f-431d-8bed-9733f98dbb08",
+      "bundleSize": 1,
+      "bundleId": 0,
+      "recordId": 0,
+      "serialNumber": 0
+    },
+    "odeReceivedAt": "2025-09-25T17:27:01.137Z",
+    "schemaVersion": 9,
+    "maxDurationTime": 0,
+    "recordGeneratedAt": "",
+    "recordGeneratedBy": "RSU",
+    "sanitized": false,
+    "odePacketID": "",
+    "odeTimStartDateTime": "",
+    "asn1": "001E1865B80579181E00F0BD480C95E46CC2981428200408430AA0",
+    "source": "RSU",
+    "originIp": "172.18.0.1",
+    "isCertPresent": false
+  },
+  "payload": {
+    "data": {
+      "messageId": 30,
+      "value": {
+        "SignalStatusMessage": {
+          "timeStamp": 374789,
+          "sequenceNumber": 15,
+          "status": [
+            {
+              "sequenceNumber": 30,
+              "id": {
+                "id": 12114
+              },
+              "sigStatus": [
+                {
+                  "requester": {
+                    "id": {
+                      "stationID": 2031825062
+                    },
+                    "request": 5,
+                    "sequenceNumber": 5,
+                    "role": "publicTransport"
+                  },
+                  "outboundOn": {
+                    "lane": 16
+                  },
+                  "duration": 34325,
+                  "status": "granted"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "dataType": "us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame"
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/sample.processed-srm-multi.json
+++ b/jpo-geojsonconverter/src/test/resources/json/sample.processed-srm-multi.json
@@ -1,0 +1,46 @@
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      -105.0851191,
+      39.5532496
+    ]
+  },
+  "properties": {
+    "schemaVersion": 1,
+    "messageType": "SRM",
+    "odeReceivedAt": "2025-09-26T20:22:46.101Z",
+    "originIp": "172.18.0.1",
+    "asn1": "001D2F72DC028000050890BD481080201F1A62242F5205200408430AB02F236614C002D4D3841D02CA71A8851970D51C3060",
+    "timeStamp": "2025-09-18T06:29:00Z",
+    "sequenceNumber": 5,
+    "vehicleID": "2031825062",
+    "role": "PUBLICTRANSPORT",
+    "latitude": 39.5532496,
+    "longitude": -105.0851191,
+    "elevation": 1679.1000000000001,
+    "heading": 21.3,
+    "transmission": "UNAVAILABLE",
+    "speedMetersPerSecond": 7.74,
+    "requests": [
+      {
+        "intersectionId": 12114,
+        "requestID": 4,
+        "priorityRequestType": "PRIORITYREQUEST",
+        "inboundLaneID": 2,
+        "outboundLaneID": 15,
+        "estimatedTimeOfArrivalDurationSeconds": 36.145000000
+      },
+      {
+        "intersectionId": 12114,
+        "requestID": 5,
+        "priorityRequestType": "PRIORITYREQUEST",
+        "inboundLaneID": 1,
+        "outboundLaneID": 16,
+        "estimatedTimeOfArrivalDurationSeconds": 34.325000000
+      }
+    ],
+    "validationMessages": []
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/sample.processed-srm.json
+++ b/jpo-geojsonconverter/src/test/resources/json/sample.processed-srm.json
@@ -1,0 +1,46 @@
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      -105.0851191,
+      39.5532496
+    ]
+  },
+  "properties": {
+    "schemaVersion": 1,
+    "messageType": "SRM",
+    "odeReceivedAt": "2025-09-26T00:46:10.771Z",
+    "originIp": "172.18.0.1",
+    "asn1": "001D2F72DC028000050890BD481080201F1A62242F5205200408430AB02F236614C002D4D3841D02CA71A8851970D51C3060",
+    "timeStamp": "2025-09-18T06:29:00Z",
+    "sequenceNumber": 5,
+    "vehicleID": "2031825062",
+    "role": "PUBLICTRANSPORT",
+    "latitude": 39.5532496,
+    "longitude": -105.0851191,
+    "elevation": 1679.1000000000001,
+    "heading": 21.3,
+    "transmission": "UNAVAILABLE",
+    "speedMetersPerSecond": 7.74,
+    "requests": [
+      {
+        "intersectionId": 12114,
+        "requestID": 4,
+        "priorityRequestType": "PRIORITYREQUEST",
+        "inboundLaneID": 2,
+        "outboundLaneID": 15,
+        "estimatedTimeOfArrivalDurationSeconds": 36.145000000
+      },
+      {
+        "intersectionId": 12114,
+        "requestID": 5,
+        "priorityRequestType": "PRIORITYREQUEST",
+        "inboundLaneID": 1,
+        "outboundLaneID": 16,
+        "estimatedTimeOfArrivalDurationSeconds": 34.325000000
+      }
+    ],
+    "validationMessages": []
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/sample.processed-ssm-multi.json
+++ b/jpo-geojsonconverter/src/test/resources/json/sample.processed-ssm-multi.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "messageType": "SSM",
+  "asn1": "001E2565B8056D601800E8BD482C95E46CC2981028200807C30A9325791B30A6050A08010210C2A4",
+  "odeReceivedAt": "2025-09-26T20:26:31.73Z",
+  "originIp": "172.18.0.1",
+  "timeStamp": "2025-09-18T06:29:28Z",
+  "sequenceNumber": 12,
+  "statusSequenceNumber": 29,
+  "intersectionId": 12114,
+  "statusList": [
+    {
+      "vehicleID": "2031825062",
+      "requestID": 4,
+      "requesterSequenceNumber": 5,
+      "requesterRole": "PUBLICTRANSPORT",
+      "inboundOnLaneID": 2,
+      "outboundOnLaneID": 15,
+      "estimatedTimeOfArrivalDurationSeconds": 34.325000000,
+      "status": "PROCESSING"
+    },
+    {
+      "vehicleID": "2031825062",
+      "requestID": 5,
+      "requesterSequenceNumber": 5,
+      "requesterRole": "PUBLICTRANSPORT",
+      "inboundOnLaneID": 1,
+      "outboundOnLaneID": 16,
+      "estimatedTimeOfArrivalDurationSeconds": 34.325000000,
+      "status": "PROCESSING"
+    }
+  ],
+  "validationMessages": []
+}

--- a/jpo-geojsonconverter/src/test/resources/json/sample.processed-ssm.json
+++ b/jpo-geojsonconverter/src/test/resources/json/sample.processed-ssm.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "messageType": "SSM",
+  "asn1": "001E2565B8056D601800E8BD482C95E46CC2981028200807C30A9325791B30A6050A08010210C2A4",
+  "odeReceivedAt": "2025-09-26T00:55:06.425Z",
+  "originIp": "172.18.0.1",
+  "timeStamp": "2025-09-18T06:29:28Z",
+  "sequenceNumber": 12,
+  "statusSequenceNumber": 29,
+  "intersectionId": 12114,
+  "statusList": [
+    {
+      "vehicleID": "2031825062",
+      "requestID": 4,
+      "requesterSequenceNumber": 5,
+      "requesterRole": "PUBLICTRANSPORT",
+      "inboundOnLaneID": 2,
+      "outboundOnLaneID": 15,
+      "estimatedTimeOfArrivalDurationSeconds": 34.325000000,
+      "status": "PROCESSING"
+    },
+    {
+      "vehicleID": "2031825062",
+      "requestID": 5,
+      "requesterSequenceNumber": 5,
+      "requesterRole": "PUBLICTRANSPORT",
+      "inboundOnLaneID": 1,
+      "outboundOnLaneID": 16,
+      "estimatedTimeOfArrivalDurationSeconds": 34.325000000,
+      "status": "PROCESSING"
+    }
+  ],
+  "validationMessages": []
+}

--- a/jpo-geojsonconverter/src/test/resources/json/srm.message-frame.2lanes.json
+++ b/jpo-geojsonconverter/src/test/resources/json/srm.message-frame.2lanes.json
@@ -1,0 +1,64 @@
+{
+  "messageId": 29,
+  "value": {
+    "SignalRequestMessage": {
+      "timeStamp": 374789,
+      "second": 0,
+      "sequenceNumber": 8,
+      "requests": [
+        {
+          "request": {
+            "id": {
+              "id": 12114
+            },
+            "requestID": 5,
+            "requestType": "priorityRequest",
+            "inBoundLane": {
+              "lane": 1
+            },
+            "outBoundLane": {
+              "lane": 16
+            }
+          },
+          "duration": 34325
+        },
+        {
+          "request": {
+            "id": {
+              "id": 12114
+            },
+            "requestID": 4,
+            "requestType": "priorityCancellation",
+            "inBoundLane": {
+              "lane": 2
+            },
+            "outBoundLane": {
+              "lane": 15
+            }
+          },
+          "duration": 36145
+        }
+      ],
+      "requestor": {
+        "id": {
+          "stationID": 2031825062
+        },
+        "type": {
+          "role": "publicTransport"
+        },
+        "position": {
+          "position": {
+            "lat": 395533186,
+            "long": -1050850893,
+            "elevation": 16791
+          },
+          "heading": 1312,
+          "speed": {
+            "transmisson": "unavailable",
+            "speed": 418
+          }
+        }
+      }
+    }
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/srm.message-frame.4lanes.json
+++ b/jpo-geojsonconverter/src/test/resources/json/srm.message-frame.4lanes.json
@@ -1,0 +1,96 @@
+{
+  "messageId": 29,
+  "value": {
+    "SignalRequestMessage": {
+      "timeStamp": 374532,
+      "second": 0,
+      "sequenceNumber": 9,
+      "requests": [
+        {
+          "request": {
+            "id": {
+              "id": 8802
+            },
+            "requestID": 4,
+            "requestType": "priorityCancellation",
+            "inBoundLane": {
+              "lane": 28
+            },
+            "outBoundLane": {
+              "lane": 26
+            }
+          },
+          "duration": 5624
+        },
+        {
+          "request": {
+            "id": {
+              "id": 8802
+            },
+            "requestID": 3,
+            "requestType": "priorityCancellation",
+            "inBoundLane": {
+              "lane": 1
+            },
+            "outBoundLane": {
+              "lane": 19
+            }
+          },
+          "duration": 6078
+        },
+        {
+          "request": {
+            "id": {
+              "id": 8802
+            },
+            "requestID": 1,
+            "requestType": "priorityCancellation",
+            "inBoundLane": {
+              "lane": 3
+            },
+            "outBoundLane": {
+              "lane": 17
+            }
+          },
+          "duration": 6173
+        },
+        {
+          "request": {
+            "id": {
+              "id": 8802
+            },
+            "requestID": 2,
+            "requestType": "priorityCancellation",
+            "inBoundLane": {
+              "lane": 2
+            },
+            "outBoundLane": {
+              "lane": 18
+            }
+          },
+          "duration": 6101
+        }
+      ],
+      "requestor": {
+        "id": {
+          "stationID": 312977750
+        },
+        "type": {
+          "role": "publicTransport"
+        },
+        "position": {
+          "position": {
+            "lat": 395939481,
+            "long": -1048844050,
+            "elevation": 17525
+          },
+          "heading": 12568,
+          "speed": {
+            "transmisson": "unavailable",
+            "speed": 1417
+          }
+        }
+      }
+    }
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/srm.message-frame.json
+++ b/jpo-geojsonconverter/src/test/resources/json/srm.message-frame.json
@@ -1,0 +1,48 @@
+{
+  "messageId": 29,
+  "value": {
+    "SignalRequestMessage": {
+      "timeStamp": 374789,
+      "second": 0,
+      "sequenceNumber": 11,
+      "requests": [
+        {
+          "request": {
+            "id": {
+              "id": 12114
+            },
+            "requestID": 5,
+            "requestType": "priorityRequest",
+            "inBoundLane": {
+              "lane": 1
+            },
+            "outBoundLane": {
+              "lane": 16
+            }
+          },
+          "duration": 34325
+        }
+      ],
+      "requestor": {
+        "id": {
+          "stationID": 2031825062
+        },
+        "type": {
+          "role": "publicTransport"
+        },
+        "position": {
+          "position": {
+            "lat": 395534788,
+            "long": -1050850214,
+            "elevation": 16788
+          },
+          "heading": 1496,
+          "speed": {
+            "transmisson": "unavailable",
+            "speed": 512
+          }
+        }
+      }
+    }
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/ssm.message-frame.json
+++ b/jpo-geojsonconverter/src/test/resources/json/ssm.message-frame.json
@@ -1,0 +1,38 @@
+{
+  "messageId": 30,
+  "value": {
+    "SignalStatusMessage": {
+      "timeStamp": 374789,
+      "second": 31000,
+      "sequenceNumber": 15,
+      "status": [
+        {
+          "sequenceNumber": 30,
+          "id": {
+            "id": 12114
+          },
+          "sigStatus": [
+            {
+              "requester": {
+                "id": {
+                  "stationID": 2031825062
+                },
+                "request": 5,
+                "sequenceNumber": 5,
+                "role": "publicTransport"
+              },
+              "inboundOn": {
+                "lane": 1
+              },
+              "outboundOn": {
+                "lane": 16
+              },
+              "duration": 34325,
+              "status": "granted"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/ssm.message-frame.multi.json
+++ b/jpo-geojsonconverter/src/test/resources/json/ssm.message-frame.multi.json
@@ -1,0 +1,56 @@
+{
+  "messageId": 30,
+  "value": {
+    "SignalStatusMessage": {
+      "timeStamp": 374789,
+      "second": 28000,
+      "sequenceNumber": 12,
+      "status": [
+        {
+          "sequenceNumber": 29,
+          "id": {
+            "id": 12114
+          },
+          "sigStatus": [
+            {
+              "requester": {
+                "id": {
+                  "stationID": 2031825062
+                },
+                "request": 4,
+                "sequenceNumber": 5,
+                "role": "publicTransport"
+              },
+              "inboundOn": {
+                "lane": 2
+              },
+              "outboundOn": {
+                "lane": 15
+              },
+              "duration": 34325,
+              "status": "processing"
+            },
+            {
+              "requester": {
+                "id": {
+                  "stationID": 2031825062
+                },
+                "request": 5,
+                "sequenceNumber": 5,
+                "role": "publicTransport"
+              },
+              "inboundOn": {
+                "lane": 1
+              },
+              "outboundOn": {
+                "lane": 16
+              },
+              "duration": 34325,
+              "status": "processing"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/valid.srm-multi.json
+++ b/jpo-geojsonconverter/src/test/resources/json/valid.srm-multi.json
@@ -1,0 +1,97 @@
+{
+  "metadata": {
+    "logFileName": "",
+    "recordType": "srmTx",
+    "securityResultCode": "success",
+    "receivedMessageDetails": {
+      "rxSource": "NA"
+    },
+    "payloadType": "us.dot.its.jpo.ode.model.OdeMessageFramePayload",
+    "serialId": {
+      "streamId": "ab0906f8-6743-4355-b5ca-84f6d47ce475",
+      "bundleSize": 1,
+      "bundleId": 0,
+      "recordId": 0,
+      "serialNumber": 0
+    },
+    "odeReceivedAt": "2025-09-26T20:22:46.101Z",
+    "schemaVersion": 9,
+    "maxDurationTime": 0,
+    "recordGeneratedAt": "",
+    "recordGeneratedBy": "OBU",
+    "sanitized": false,
+    "odePacketID": "",
+    "odeTimStartDateTime": "",
+    "asn1": "001D2F72DC028000050890BD481080201F1A62242F5205200408430AB02F236614C002D4D3841D02CA71A8851970D51C3060",
+    "source": "RSU",
+    "originIp": "172.18.0.1",
+    "isCertPresent": false
+  },
+  "payload": {
+    "data": {
+      "messageId": 29,
+      "value": {
+        "SignalRequestMessage": {
+          "timeStamp": 374789,
+          "second": 0,
+          "sequenceNumber": 5,
+          "requests": [
+            {
+              "request": {
+                "id": {
+                  "id": 12114
+                },
+                "requestID": 4,
+                "requestType": "priorityRequest",
+                "inBoundLane": {
+                  "lane": 2
+                },
+                "outBoundLane": {
+                  "lane": 15
+                }
+              },
+              "duration": 36145
+            },
+            {
+              "request": {
+                "id": {
+                  "id": 12114
+                },
+                "requestID": 5,
+                "requestType": "priorityRequest",
+                "inBoundLane": {
+                  "lane": 1
+                },
+                "outBoundLane": {
+                  "lane": 16
+                }
+              },
+              "duration": 34325
+            }
+          ],
+          "requestor": {
+            "id": {
+              "stationID": 2031825062
+            },
+            "type": {
+              "role": "publicTransport"
+            },
+            "position": {
+              "position": {
+                "lat": 395532496,
+                "long": -1050851191,
+                "elevation": 16791
+              },
+              "heading": 1704,
+              "speed": {
+                "transmisson": "unavailable",
+                "speed": 387
+              }
+            }
+          }
+        }
+      }
+    },
+    "dataType": "us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame"
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/valid.srm.json
+++ b/jpo-geojsonconverter/src/test/resources/json/valid.srm.json
@@ -1,0 +1,81 @@
+{
+  "metadata": {
+    "logFileName": "",
+    "recordType": "srmTx",
+    "securityResultCode": "success",
+    "receivedMessageDetails": {
+      "rxSource": "NA"
+    },
+    "payloadType": "us.dot.its.jpo.ode.model.OdeMessageFramePayload",
+    "serialId": {
+      "streamId": "b18d90c6-448a-4019-b259-12232676c718",
+      "bundleSize": 1,
+      "bundleId": 0,
+      "recordId": 0,
+      "serialNumber": 0
+    },
+    "odeReceivedAt": "2025-09-25T17:26:11.873Z",
+    "schemaVersion": 9,
+    "maxDurationTime": 0,
+    "recordGeneratedAt": "",
+    "recordGeneratedBy": "OBU",
+    "sanitized": false,
+    "odePacketID": "",
+    "odeTimStartDateTime": "",
+    "asn1": "001D2672DC0280000B0090BD48148010210C2AC0BC8D9853000B534E12B10B29C796546502EC710000",
+    "source": "RSU",
+    "originIp": "172.18.0.1",
+    "isCertPresent": false
+  },
+  "payload": {
+    "data": {
+      "messageId": 29,
+      "value": {
+        "SignalRequestMessage": {
+          "timeStamp": 374789,
+          "second": 0,
+          "sequenceNumber": 11,
+          "requests": [
+            {
+              "request": {
+                "id": {
+                  "id": 12114
+                },
+                "requestID": 5,
+                "requestType": "priorityRequest",
+                "inBoundLane": {
+                  "lane": 1
+                },
+                "outBoundLane": {
+                  "lane": 16
+                }
+              },
+              "duration": 34325
+            }
+          ],
+          "requestor": {
+            "id": {
+              "stationID": 2031825062
+            },
+            "type": {
+              "role": "publicTransport"
+            },
+            "position": {
+              "position": {
+                "lat": 395534788,
+                "long": -1050850214,
+                "elevation": 16788
+              },
+              "heading": 1496,
+              "speed": {
+                "transmisson": "unavailable",
+                "speed": 512
+              }
+            }
+          }
+        }
+      }
+    },
+    "dataType": "us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame"
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/valid.ssm-multi.json
+++ b/jpo-geojsonconverter/src/test/resources/json/valid.ssm-multi.json
@@ -1,0 +1,89 @@
+{
+  "metadata": {
+    "logFileName": "",
+    "recordType": "ssmTx",
+    "securityResultCode": "success",
+    "receivedMessageDetails": {
+      "rxSource": "NA"
+    },
+    "payloadType": "us.dot.its.jpo.ode.model.OdeMessageFramePayload",
+    "serialId": {
+      "streamId": "126db3cd-bbf3-43ce-8bc8-71d136d0b1c9",
+      "bundleSize": 1,
+      "bundleId": 0,
+      "recordId": 0,
+      "serialNumber": 0
+    },
+    "odeReceivedAt": "2025-09-26T20:26:21.570Z",
+    "schemaVersion": 9,
+    "maxDurationTime": 0,
+    "recordGeneratedAt": "",
+    "recordGeneratedBy": "RSU",
+    "sanitized": false,
+    "odePacketID": "",
+    "odeTimStartDateTime": "",
+    "asn1": "001E2565B8056D601800E8BD482C95E46CC2981028200807C30A9325791B30A6050A08010210C2A4",
+    "source": "RSU",
+    "originIp": "172.18.0.1",
+    "isCertPresent": false
+  },
+  "payload": {
+    "data": {
+      "messageId": 30,
+      "value": {
+        "SignalStatusMessage": {
+          "timeStamp": 374789,
+          "second": 28000,
+          "sequenceNumber": 12,
+          "status": [
+            {
+              "sequenceNumber": 29,
+              "id": {
+                "id": 12114
+              },
+              "sigStatus": [
+                {
+                  "requester": {
+                    "id": {
+                      "stationID": 2031825062
+                    },
+                    "request": 4,
+                    "sequenceNumber": 5,
+                    "role": "publicTransport"
+                  },
+                  "inboundOn": {
+                    "lane": 2
+                  },
+                  "outboundOn": {
+                    "lane": 15
+                  },
+                  "duration": 34325,
+                  "status": "processing"
+                },
+                {
+                  "requester": {
+                    "id": {
+                      "stationID": 2031825062
+                    },
+                    "request": 5,
+                    "sequenceNumber": 5,
+                    "role": "publicTransport"
+                  },
+                  "inboundOn": {
+                    "lane": 1
+                  },
+                  "outboundOn": {
+                    "lane": 16
+                  },
+                  "duration": 34325,
+                  "status": "processing"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "dataType": "us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame"
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/valid.ssm.json
+++ b/jpo-geojsonconverter/src/test/resources/json/valid.ssm.json
@@ -1,0 +1,71 @@
+{
+  "metadata": {
+    "logFileName": "",
+    "recordType": "ssmTx",
+    "securityResultCode": "success",
+    "receivedMessageDetails": {
+      "rxSource": "NA"
+    },
+    "payloadType": "us.dot.its.jpo.ode.model.OdeMessageFramePayload",
+    "serialId": {
+      "streamId": "64c77df2-e59f-431d-8bed-9733f98dbb08",
+      "bundleSize": 1,
+      "bundleId": 0,
+      "recordId": 0,
+      "serialNumber": 0
+    },
+    "odeReceivedAt": "2025-09-25T17:27:01.137Z",
+    "schemaVersion": 9,
+    "maxDurationTime": 0,
+    "recordGeneratedAt": "",
+    "recordGeneratedBy": "RSU",
+    "sanitized": false,
+    "odePacketID": "",
+    "odeTimStartDateTime": "",
+    "asn1": "001E1865B80579181E00F0BD480C95E46CC2981428200408430AA0",
+    "source": "RSU",
+    "originIp": "172.18.0.1",
+    "isCertPresent": false
+  },
+  "payload": {
+    "data": {
+      "messageId": 30,
+      "value": {
+        "SignalStatusMessage": {
+          "timeStamp": 374789,
+          "second": 31000,
+          "sequenceNumber": 15,
+          "status": [
+            {
+              "sequenceNumber": 30,
+              "id": {
+                "id": 12114
+              },
+              "sigStatus": [
+                {
+                  "requester": {
+                    "id": {
+                      "stationID": 2031825062
+                    },
+                    "request": 5,
+                    "sequenceNumber": 5,
+                    "role": "publicTransport"
+                  },
+                  "inboundOn": {
+                    "lane": 1
+                  },
+                  "outboundOn": {
+                    "lane": 16
+                  },
+                  "duration": 34325,
+                  "status": "granted"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "dataType": "us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame"
+  }
+}

--- a/jpo-geojsonconverter/src/test/resources/logback-test.xml
+++ b/jpo-geojsonconverter/src/test/resources/logback-test.xml
@@ -4,7 +4,7 @@
       <pattern>%msg%n</pattern>
     </encoder>
   </appender>
-  <root level="OFF">
+  <root level="INFO">
     <appender-ref ref="CONSOLE"/>
   </root>
 </configuration>


### PR DESCRIPTION
Adds Processed SRM and SSM messages.

Consumes from the ODE topics:
* topic.OdeSrmJson
* topic.OdeSsmJson

Produces to new topics (see the [related jpo-utils PR](https://github.com/CDOT-CV/jpo-utils/pull/39) that creates the topics)
* topic.ProcessedSrm
* topic.ProcessedSsm

Examples:
* [ProcessedSrm Example](https://github.com/CDOT-CV/jpo-geojsonconverter/blob/3e2e0d523286f26e02ca11fd5a3c60510212167c/jpo-geojsonconverter/src/test/resources/json/sample.processed-srm-multi.json)
* [ProcessedSsm Example](https://github.com/CDOT-CV/jpo-geojsonconverter/blob/3e2e0d523286f26e02ca11fd5a3c60510212167c/jpo-geojsonconverter/src/test/resources/json/sample.processed-ssm-multi.json)


## Desired features of the processed objects:

1. Display as GeoJSON on a map
2. Countability: 1 Processed object per 1 ODE object
3. Ability to match SRMs with SSMs, and to match SSMs with MAPs

## ProcessedSrm Design

SRMs are similar to BSMs in that they are sent from a vehicle and can include the vehicle's location. Unlike BSMs, the location is optional in SRMs, but if it is present it is used as the point geometry of a GeoJSON feature. 

It is possible for one SRM to contain requests for multiple lanes at one intersection, or to target more than one intersection, so `ProcessedSrm` data structures contain a list of requests.  We have observed actual data with multiple requests for different lanes in CDOT's installation. The processed structure retains all the requests in the SRM, even if there happened to be requests for more than one intersection.

The Kafka messages for `ProcessedSrm` use a key containing the RSU ID and VehicleID.  The intersection ID and region are not included in the key because of the possibility of a message targeting more than one intersection.

## ProcessedSsm Design

SSMs are similar to SPATs in that they don't have a geometry of their own but must be matched with a corresponding MAP message to obtain location data.  Therefore, `ProcessedSsm` objects are simple POJOs, not GeoJSON.  

Also, like SPATs, SSMs can contain groups of messages for more than one intersection, but it is anticipated that it is unlikely that they actually would, because they are broadcast from RSUs located at one intersection.  Therefore, this code takes only the first intersection from any SSM it receives, and logs a warning if an SSM contains more than one intersection.  This is the same as how SPATs are treated.

It also would be possible for SSMs to contain responses for more than one vehicle, or for requests for more than one lane for a vehicle.  We have not seen examples of SSMs with multiple statuses in a cursory check of one day of data from CDOT, but this scenario seems more likely that it could happen according to the language in the J2735 where SSMs are defined, which describes them as collections of statuses targeted for multiple vehicles and lanes. For this reason, the `ProcessedSsm` data structure contains a list of statuses.

The Kafka messages for `ProcessedSsm` use RSU ID and Intersection in the key because they are associated with only one intersection.

## CIMMS Considerations

ProcessedSsms are keyed by intersection ID to facilitate joining with MAPs.  ProcessedSrms will need to be rekeyed and repartitioned similarly to how BSMs are handled.  

Since ProcessedSrms and ProcessedSsms contain lists of requests and status, the CIMMS will need to perform a flatMap and rekey operation before joining them together to produce events for each vehicle request, but the CIMMS already does a lot of similar streams manipulations, so that will not be a problem for it.
