### PR TITLE
Processed ssm serialization

### DIFF
--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-geojsonconverter</artifactId>
-    <version>3.1.1</version>
+    <version>3.2.0</version>
     <packaging>jar</packaging>
     <name>jpo-geojsonconverter</name>
     <description>J2735 message to GeoJSON converter for US DOT ITS JPO ODE</description>

--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-geojsonconverter</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <packaging>jar</packaging>
     <name>jpo-geojsonconverter</name>
     <description>J2735 message to GeoJSON converter for US DOT ITS JPO ODE</description>

--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -194,6 +194,12 @@
             <artifactId>hibernate-validator</artifactId>
             <version>8.0.1.Final</version>
         </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <version>5.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <finalName>${project.artifactId}</finalName>

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
@@ -80,7 +80,8 @@ public class ProcessedSsm {
     private List<ProcessedSignalStatus> statusList;
 
     /*
-     * ----------------------------------------------------------------------- Validation
+     * ------------------------------------------------------------------------ 
+     * Validation
      * ------------------------------------------------------------------------
      */
     private List<ProcessedValidationMessage> validationMessages = new ArrayList<>();

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/ssm/ProcessedSsm.java
@@ -2,27 +2,34 @@ package us.dot.its.jpo.geojsonconverter.pojos.ssm;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Generated;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import us.dot.its.jpo.geojsonconverter.DateJsonMapper;
 import us.dot.its.jpo.geojsonconverter.pojos.ProcessedValidationMessage;
-import us.dot.its.jpo.geojsonconverter.pojos.common.*;
-
-import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * A Java object representing a processed J2735 MSG_SignalStatusMessage.
- * <p>The SSM may contain responses to multiple requests from multiple vehicles.</p>
- * <p>Similar to a SPAT, the SSM is associated with an intersection, but does not contain any geographic information
- * itself, therefore this is a plain Java object, not a GeoJSON object.  It must be matched with a corresponding MAP
- * message to find the intersection location.</p>
- * <p>It is possible, in theory, for an SSM to contain SignalRequests for more than one intersection, but that
- * scenario is not supported by this library.  If an SSM containing multiple intersection were received, all but the
- * first one would be discarded by the converter (similar to the behavior for SPATs).</p>
+ * <p>
+ * The SSM may contain responses to multiple requests from multiple vehicles.
+ * </p>
+ * <p>
+ * Similar to a SPAT, the SSM is associated with an intersection, but does not contain any geographic information
+ * itself, therefore this is a plain Java object, not a GeoJSON object. It must be matched with a corresponding MAP
+ * message to find the intersection location.
+ * </p>
+ * <p>
+ * It is possible, in theory, for an SSM to contain SignalRequests for more than one intersection, but that scenario is
+ * not supported by this library. If an SSM containing multiple intersection were received, all but the first one would
+ * be discarded by the converter (similar to the behavior for SPATs).
+ * </p>
  */
 @Data
 @NoArgsConstructor
@@ -30,6 +37,7 @@ import java.util.List;
 @Generated
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Slf4j
 public class ProcessedSsm {
     private int schemaVersion = -1;
     private final String messageType = "SSM";
@@ -46,7 +54,7 @@ public class ProcessedSsm {
 
     /**
      * Top-level timestamp of MSG_SignalStatusMessage
-      */
+     */
     private ZonedDateTime timeStamp;
 
     /**
@@ -71,9 +79,10 @@ public class ProcessedSsm {
 
     private List<ProcessedSignalStatus> statusList;
 
-    /* -----------------------------------------------------------------------
-        Validation
-    ------------------------------------------------------------------------*/
+    /*
+     * ----------------------------------------------------------------------- Validation
+     * ------------------------------------------------------------------------
+     */
     private List<ProcessedValidationMessage> validationMessages = new ArrayList<>();
 
     public void addValidationMessage(ProcessedValidationMessage message) {
@@ -94,5 +103,17 @@ public class ProcessedSsm {
         var validationMessage = new ProcessedValidationMessage();
         validationMessage.setMessage(message);
         addValidationMessage(validationMessage);
+    }
+
+    @Override
+    public String toString() {
+        ObjectMapper mapper = DateJsonMapper.getInstance();
+        String testReturn = "";
+        try {
+            testReturn = (mapper.writeValueAsString(this));
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage(), e);
+        }
+        return testReturn;
     }
 }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmSerializationTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmSerializationTest.java
@@ -1,6 +1,5 @@
 package us.dot.its.jpo.geojsonconverter.converter.ssm;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import org.junit.Test;
@@ -10,6 +9,7 @@ import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMes
 import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
 import us.dot.its.jpo.geojsonconverter.utils.ProcessedSchemaVersions;
 import static us.dot.its.jpo.geojsonconverter.TestResourceUtil.loadResource;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @Slf4j
 public class SsmSerializationTest {
@@ -24,19 +24,11 @@ public class SsmSerializationTest {
         SignalStatusMessageMessageFrame messageFrame = mapper.readValue(ssmJson, SignalStatusMessageMessageFrame.class);
         ProcessedSsm processedSsm = ssmConverter.processSsm(messageFrame);
 
-
-        System.out.println("\n\n\nSerializing SSM Json" + ssmJson);
-        System.out.println("\n\n\nSerializing Processed SSM" + processedSsm.toString());
-
-
         processedSsm.setOdeReceivedAt(ZonedDateTime.parse("2025-09-18T06:29:28Z"));
         processedSsm.setAsn1("001E1865B80579181E00F0BD480C95E46CC2981428200408430AA0");
         processedSsm.setSchemaVersion(ProcessedSchemaVersions.PROCESSED_SSM_SCHEMA_VERSION);
         processedSsm.setOriginIp("172.18.0.1");
 
-        // Forcibly remove newlines and spaces to make sure IDE json formatting doesn't mess up test performance
-        String compareString = processedSsm.toString().replaceAll("\n", "").replaceAll(" ", "");
-        String compareReference = referenceProcessedSsmJson.replaceAll("\n", "").replaceAll(" ", "");
-        assertEquals(compareReference, compareString);
+        assertThatJson(referenceProcessedSsmJson).isEqualTo(processedSsm.toString());
     }
 }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmSerializationTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmSerializationTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame;
 import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+import us.dot.its.jpo.geojsonconverter.utils.ProcessedSchemaVersions;
 import static us.dot.its.jpo.geojsonconverter.TestResourceUtil.loadResource;
 
 @Slf4j
@@ -23,7 +24,15 @@ public class SsmSerializationTest {
         SignalStatusMessageMessageFrame messageFrame = mapper.readValue(ssmJson, SignalStatusMessageMessageFrame.class);
         ProcessedSsm processedSsm = ssmConverter.processSsm(messageFrame);
 
+
+        System.out.println("\n\n\nSerializing SSM Json" + ssmJson);
+        System.out.println("\n\n\nSerializing Processed SSM" + processedSsm.toString());
+
+
         processedSsm.setOdeReceivedAt(ZonedDateTime.parse("2025-09-18T06:29:28Z"));
+        processedSsm.setAsn1("001E1865B80579181E00F0BD480C95E46CC2981428200408430AA0");
+        processedSsm.setSchemaVersion(ProcessedSchemaVersions.PROCESSED_SSM_SCHEMA_VERSION);
+        processedSsm.setOriginIp("172.18.0.1");
 
         // Forcibly remove newlines and spaces to make sure IDE json formatting doesn't mess up test performance
         String compareString = processedSsm.toString().replaceAll("\n", "").replaceAll(" ", "");

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmSerializationTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmSerializationTest.java
@@ -1,0 +1,33 @@
+package us.dot.its.jpo.geojsonconverter.converter.ssm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import org.junit.Test;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import us.dot.its.jpo.asn.j2735.r2024.SignalStatusMessage.SignalStatusMessageMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.ssm.ProcessedSsm;
+import static us.dot.its.jpo.geojsonconverter.TestResourceUtil.loadResource;
+
+@Slf4j
+public class SsmSerializationTest {
+
+    private final static ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void testProcessSsmSerialization() throws IOException {
+        final String ssmJson = loadResource("classpath:json/ssm.message-frame.json");
+        final String referenceProcessedSsmJson = loadResource("classpath:json/sample.processed-ssm.json");
+        SsmConverter ssmConverter = new SsmConverter();
+        SignalStatusMessageMessageFrame messageFrame = mapper.readValue(ssmJson, SignalStatusMessageMessageFrame.class);
+        ProcessedSsm processedSsm = ssmConverter.processSsm(messageFrame);
+
+        processedSsm.setOdeReceivedAt(ZonedDateTime.parse("2025-09-18T06:29:28Z"));
+
+        // Forcibly remove newlines and spaces to make sure IDE json formatting doesn't mess up test performance
+        String compareString = processedSsm.toString().replaceAll("\n", "").replaceAll(" ", "");
+        String compareReference = referenceProcessedSsmJson.replaceAll("\n", "").replaceAll(" ", "");
+        assertEquals(compareReference, compareString);
+    }
+}

--- a/jpo-geojsonconverter/src/test/resources/json/sample.processed-ssm.json
+++ b/jpo-geojsonconverter/src/test/resources/json/sample.processed-ssm.json
@@ -1,7 +1,9 @@
 {
-  "schemaVersion": -1,
+  "schemaVersion": 1,
   "messageType": "SSM",
+  "asn1": "001E1865B80579181E00F0BD480C95E46CC2981428200408430AA0",
   "odeReceivedAt": "2025-09-18T06:29:28Z",
+  "originIp": "172.18.0.1",
   "timeStamp": "2025-09-18T06:29:31Z",
   "sequenceNumber": 15,
   "statusSequenceNumber": 30,

--- a/jpo-geojsonconverter/src/test/resources/json/sample.processed-ssm.json
+++ b/jpo-geojsonconverter/src/test/resources/json/sample.processed-ssm.json
@@ -1,24 +1,12 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": -1,
   "messageType": "SSM",
-  "asn1": "001E2565B8056D601800E8BD482C95E46CC2981028200807C30A9325791B30A6050A08010210C2A4",
-  "odeReceivedAt": "2025-09-26T00:55:06.425Z",
-  "originIp": "172.18.0.1",
-  "timeStamp": "2025-09-18T06:29:28Z",
-  "sequenceNumber": 12,
-  "statusSequenceNumber": 29,
+  "odeReceivedAt": "2025-09-18T06:29:28Z",
+  "timeStamp": "2025-09-18T06:29:31Z",
+  "sequenceNumber": 15,
+  "statusSequenceNumber": 30,
   "intersectionId": 12114,
   "statusList": [
-    {
-      "vehicleID": "2031825062",
-      "requestID": 4,
-      "requesterSequenceNumber": 5,
-      "requesterRole": "PUBLICTRANSPORT",
-      "inboundOnLaneID": 2,
-      "outboundOnLaneID": 15,
-      "estimatedTimeOfArrivalDurationSeconds": 34.325000000,
-      "status": "PROCESSING"
-    },
     {
       "vehicleID": "2031825062",
       "requestID": 5,
@@ -27,7 +15,7 @@
       "inboundOnLaneID": 1,
       "outboundOnLaneID": 16,
       "estimatedTimeOfArrivalDurationSeconds": 34.325000000,
-      "status": "PROCESSING"
+      "status": "GRANTED"
     }
   ],
   "validationMessages": []


### PR DESCRIPTION
There is a bug where the ProcessedSsm message is missing the Jackson override to the toString method. This causes issues with serializing the Processed Ssm message in downstream applications (namely the Intersection-API). This PR adds in a toString method to the ProcessedSsm class so that is behaves similar to all other serializers and serializes to JSON data. A unit test has also been added to demonstrate this functionality. Note, the sample.processed-ssm.json file was modified as the previous sample file matched the multi-ssm instead of the single ssm message frame.