### PR TITLE
Unit Test Failure Current Year Fix

### DIFF
--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverter.java
@@ -25,12 +25,6 @@ import static us.dot.its.jpo.geojsonconverter.converter.FieldConversions.*;
 @Slf4j
 public class SrmConverter {
 
-    public ProcessedSrm processSrm(final SignalRequestMessageMessageFrame ssmFrame) {
-        // We don't know what year it is; pass in the current time as a basis to guess the year.
-        var now = ZonedDateTime.now();
-        return processSrm(ssmFrame, now);
-    }
-
     public ProcessedSrm processSrm(final SignalRequestMessageMessageFrame srmFrame, final ZonedDateTime ingestTime) {
         var list = new ArrayList<ProcessedSrm>();
 
@@ -80,7 +74,9 @@ public class SrmConverter {
     }
 
     private void processRequestorDescription(final RequestorDescription requestor, SrmProperties props) {
-        if (requestor == null) { return; }
+        if (requestor == null) {
+            return;
+        }
         RequestorPositionVector vector = requestor.getPosition();
         processRequestorPositionVector(vector, props);
 
@@ -145,14 +141,18 @@ public class SrmConverter {
         }
     }
 
-    private void processSignalRequestPackage(final SignalRequestPackage pkg, final ProcessedSignalRequest processed, final int year) {
-        if (pkg == null) { return; }
+    private void processSignalRequestPackage(final SignalRequestPackage pkg, final ProcessedSignalRequest processed,
+            final int year) {
+        if (pkg == null) {
+            return;
+        }
         processSignalRequest(pkg.getRequest(), processed);
         processETA(pkg, processed, year);
     }
 
     private void processSignalRequest(final SignalRequest request, final ProcessedSignalRequest processed) {
-        if (request == null) return;
+        if (request == null)
+            return;
 
         RegionIntersectionId id = convertIntersectionReferenceID(request.getId());
         processed.setRegion(id.region());
@@ -160,7 +160,7 @@ public class SrmConverter {
 
         RequestID requestId = request.getRequestID();
         if (requestId != null) {
-            processed.setRequestID((int)requestId.getValue());
+            processed.setRequestID((int) requestId.getValue());
         }
 
         PriorityRequestType requestType = request.getRequestType();
@@ -180,7 +180,7 @@ public class SrmConverter {
     }
 
     private void processETA(final SignalRequestPackage pkg, final ProcessedSignalRequest processed, final int year) {
-        ZonedDateTime ts = convertMinuteOfYearAndDSecond( pkg.getMinute(), year, pkg.getSecond());
+        ZonedDateTime ts = convertMinuteOfYearAndDSecond(pkg.getMinute(), year, pkg.getSecond());
         processed.setEstimatedTimeOfArrival(ts);
         if (pkg.getDuration() != null) {
             Duration duration = Duration.ofMillis(pkg.getDuration().getValue());
@@ -189,19 +189,21 @@ public class SrmConverter {
     }
 
     private void processRequestorType(RequestorType requestorType, SrmProperties props) {
-        if (requestorType == null) return;
+        if (requestorType == null)
+            return;
         props.setRole(convertBasicVehicleRole(requestorType.getRole()));
         props.setSubrole(convertRequestSubRole(requestorType.getSubrole()));
         props.setHpmsType(convertVehicleType(requestorType.getHpmsType()));
         Iso3833VehicleType iso = requestorType.getIso3883();
         if (iso != null) {
-            props.setIso3833VehicleType((int)iso.getValue());
+            props.setIso3833VehicleType((int) iso.getValue());
         }
         props.setImportanceLevel(convertRequestImportanceLevel(requestorType.getRequest()));
     }
 
     /**
      * Add JSON schema validation results for J2735 and Metadata validation.
+     * 
      * @param properties The properties to add validation messages to
      * @param validatorResult the schema validator result
      */

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverterTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmConverterTest.java
@@ -6,9 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.springframework.core.io.DefaultResourceLoader;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSignalRequest;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
@@ -16,6 +13,7 @@ import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -43,7 +41,7 @@ public class SrmConverterTest {
         SrmConverter srmConverter = new SrmConverter();
         SignalRequestMessageMessageFrame messageFrame =
                 mapper.readValue(srmJson, SignalRequestMessageMessageFrame.class);
-        ProcessedSrm processedSrm = srmConverter.processSrm(messageFrame);
+        ProcessedSrm processedSrm = srmConverter.processSrm(messageFrame, ZonedDateTime.now());
         assertThat(processedSrm, notNullValue());
         SrmProperties props = processedSrm.getProperties();
         assertThat(props, hasProperty("requests", notNullValue()));
@@ -56,11 +54,7 @@ public class SrmConverterTest {
         final String srm1Lane = loadResource("classpath:json/srm.message-frame.json");
         final String srm2Lanes = loadResource("classpath:json/srm.message-frame.2lanes.json");
         final String srm4Lanes = loadResource("classpath:json/srm.message-frame.4lanes.json");
-        return Arrays.asList(new Object[][] {
-                { srm1Lane, 1 },
-                { srm2Lanes, 2},
-                { srm4Lanes, 4}
-        });
+        return Arrays.asList(new Object[][] {{srm1Lane, 1}, {srm2Lanes, 2}, {srm4Lanes, 4}});
     }
 
 

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmSerializationTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/srm/SrmSerializationTest.java
@@ -1,0 +1,39 @@
+package us.dot.its.jpo.geojsonconverter.converter.srm;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import org.junit.Test;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import us.dot.its.jpo.asn.j2735.r2024.SignalRequestMessage.SignalRequestMessageMessageFrame;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.ProcessedSrm;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.srm.SrmProperties;
+import us.dot.its.jpo.geojsonconverter.utils.ProcessedSchemaVersions;
+import static us.dot.its.jpo.geojsonconverter.TestResourceUtil.loadResource;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+@Slf4j
+public class SrmSerializationTest {
+
+    private final static ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void testProcessSrmSerialization() throws IOException {
+        final String srmJson = loadResource("classpath:json/srm.message-frame.json");
+        final String referenceProcessedSrmJson = loadResource("classpath:json/sample.processed-srm.json");
+        SrmConverter srmConverter = new SrmConverter();
+        SignalRequestMessageMessageFrame messageFrame =
+                mapper.readValue(srmJson, SignalRequestMessageMessageFrame.class);
+        ZonedDateTime ingestTime = ZonedDateTime.parse("2025-09-26T00:46:10.771Z");
+        ProcessedSrm processedSrm = srmConverter.processSrm(messageFrame, ingestTime);
+
+        SrmProperties properties = processedSrm.getProperties();
+        properties.setAsn1(
+                "001D2F72DC028000050890BD481080201F1A62242F5205200408430AB02F236614C002D4D3841D02CA71A8851970D51C3060");
+        properties.setSchemaVersion(ProcessedSchemaVersions.PROCESSED_SRM_SCHEMA_VERSION);
+        properties.setOriginIp("172.18.0.1");
+        properties.setOdeReceivedAt(ingestTime);
+
+        assertThatJson(referenceProcessedSrmJson).isEqualTo(processedSrm.toString());
+    }
+}

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmSerializationTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/converter/ssm/SsmSerializationTest.java
@@ -22,12 +22,13 @@ public class SsmSerializationTest {
         final String referenceProcessedSsmJson = loadResource("classpath:json/sample.processed-ssm.json");
         SsmConverter ssmConverter = new SsmConverter();
         SignalStatusMessageMessageFrame messageFrame = mapper.readValue(ssmJson, SignalStatusMessageMessageFrame.class);
-        ProcessedSsm processedSsm = ssmConverter.processSsm(messageFrame);
+        ZonedDateTime ingestTime = ZonedDateTime.parse("2025-09-18T06:29:28Z");
+        ProcessedSsm processedSsm = ssmConverter.processSsm(messageFrame, ingestTime);
 
-        processedSsm.setOdeReceivedAt(ZonedDateTime.parse("2025-09-18T06:29:28Z"));
         processedSsm.setAsn1("001E1865B80579181E00F0BD480C95E46CC2981428200408430AA0");
         processedSsm.setSchemaVersion(ProcessedSchemaVersions.PROCESSED_SSM_SCHEMA_VERSION);
         processedSsm.setOriginIp("172.18.0.1");
+        processedSsm.setOdeReceivedAt(ingestTime);
 
         assertThatJson(referenceProcessedSsmJson).isEqualTo(processedSsm.toString());
     }

--- a/jpo-geojsonconverter/src/test/resources/json/sample.processed-srm.json
+++ b/jpo-geojsonconverter/src/test/resources/json/sample.processed-srm.json
@@ -3,8 +3,8 @@
   "geometry": {
     "type": "Point",
     "coordinates": [
-      -105.0851191,
-      39.5532496
+      -105.0850214,
+      39.5534788
     ]
   },
   "properties": {
@@ -14,24 +14,16 @@
     "originIp": "172.18.0.1",
     "asn1": "001D2F72DC028000050890BD481080201F1A62242F5205200408430AB02F236614C002D4D3841D02CA71A8851970D51C3060",
     "timeStamp": "2025-09-18T06:29:00Z",
-    "sequenceNumber": 5,
+    "sequenceNumber": 11,
     "vehicleID": "2031825062",
     "role": "PUBLICTRANSPORT",
-    "latitude": 39.5532496,
-    "longitude": -105.0851191,
-    "elevation": 1679.1000000000001,
-    "heading": 21.3,
+    "latitude": 39.5534788,
+    "longitude": -105.0850214,
+    "elevation": 1678.8000000000002,
+    "heading": 18.7,
     "transmission": "UNAVAILABLE",
-    "speedMetersPerSecond": 7.74,
+    "speedMetersPerSecond": 10.24,
     "requests": [
-      {
-        "intersectionId": 12114,
-        "requestID": 4,
-        "priorityRequestType": "PRIORITYREQUEST",
-        "inboundLaneID": 2,
-        "outboundLaneID": 15,
-        "estimatedTimeOfArrivalDurationSeconds": 36.145000000
-      },
       {
         "intersectionId": 12114,
         "requestID": 5,


### PR DESCRIPTION
Changes in this PR include:
1. Formatting changes to files not previously using the `./vscode/java-formatter.xml`
2. Removal of the overloaded `processSrm` constructor that assumed a year from the current time & updated the unit tests accordingly
3. Added an `srmSerialization` unit test and fixed the sample SRM files to test this properly.